### PR TITLE
Fix for proxy to route only to containers with 80 port exposed

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -2,9 +2,12 @@
 upstream {{ $host }} {
 
 {{ range $index, $value := $containers }}
-	{{ with $address := index $value.Addresses 0 }}
+	{{ range $address := $value.Addresses }}
+	{{ if eq $address.Port "80" }}
 	server {{ $value.Gateway }}:{{ $address.HostPort }};
 	{{ end }}
+	{{ end }}
+
 {{ end }}
 
 }


### PR DESCRIPTION
I had issues with container had 2 ports exposed.. this will make sure only the 80th port is added to Nginx proxy.

Please check/ let me know if you have any questions.

I am not a Go- programmer :) today is the first time I even see this Go text templates.
