### PR TITLE
Fix for long server names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN tar xvzf docker-gen-linux-amd64-0.2.1.tar.gz
 RUN mkdir -p /var/log/supervisor
 ADD supervisor.conf /etc/supervisor/conf.d/supervisor.conf
 
-EXPOSE 443
+EXPOSE 80
 ENV DOCKER_HOST unix:///tmp/docker.sock
 
 CMD ["/usr/bin/supervisord"]


### PR DESCRIPTION
I had issues with some of my sites having really long ursl and hence was killing the Nginx before it starts with an error 

nginx: could not build the server_names_hash

Fixed it by adding this to nginx conf.
server_names_hash_bucket_size 64;
