### PR TITLE
Only add source after dependency download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 #fix for long server names
 RUN sed -i 's/# server_names_hash_bucket/server_names_hash_bucket/g' /etc/nginx/nginx.conf
 
-RUN mkdir /app
-WORKDIR /app
-ADD . /app
-
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego
 RUN chmod u+x /usr/local/bin/forego
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/0.3.2/docker-gen-linux-amd64-0.3.2.tar.gz
-RUN tar xvzf docker-gen-linux-amd64-0.3.2.tar.gz
+RUN tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-0.3.2.tar.gz
+
+RUN mkdir /app
+WORKDIR /app
+ADD . /app
 
 EXPOSE 80
 ENV DOCKER_HOST unix:///tmp/docker.sock

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 nginx: nginx
-dockergen: /app/docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/sites-enabled/default
+dockergen: docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/sites-enabled/default


### PR DESCRIPTION
This lets docker cache the ADD instruction, giving us a faster build.
Also, install docker-gen directly to /usr/local/bin.
