### PR TITLE
Pass through X-Forwarded-Proto

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,3 +1,8 @@
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
 server {
 	listen 80 default_server;
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
@@ -53,7 +58,7 @@ server {
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 
 		# HTTP 1.1 support
 		proxy_http_version 1.1;


### PR DESCRIPTION
Patches /etc/nginx/proxy_params to drop the line that sets X-Forwarded-Proto.
Any X-Forwarded-Proto header set by the upstream peer will be passed through
(e.g. from your load balanacer).

This PR is a simpler alternative to #28, which also makes other changes.
