### PR TITLE
Simplify template output

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -12,6 +12,11 @@ map $http_upgrade $proxy_connection {
   ''      '';
 }
 
+gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+access_log /proc/self/fd/1;
+error_log /proc/self/fd/2;
+
 # HTTP 1.1 support
 proxy_http_version 1.1;
 proxy_buffering off;
@@ -61,11 +66,7 @@ upstream {{ $host }} {
 }
 
 server {
-	gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-
 	server_name {{ $host }};
-	error_log /proc/self/fd/2;
-	access_log /proc/self/fd/1;
 
 	location / {
 		proxy_pass http://{{ $host }};


### PR DESCRIPTION
This PR simplifies and reduces the size of the template output by moving statements whose values don't differ per `server` or `location` block to the top level.

It also changes from dropping `Connection` to explicitly setting it to `close` in the non-`Upgrade` case.
