### PR TITLE
Optimize Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,28 +2,34 @@ FROM ubuntu:14.04
 MAINTAINER Jason Wilder jwilder@litl.com
 
 # Install Nginx.
-RUN echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" > /etc/apt/sources.list.d/nginx-stable-trusty.list
-RUN echo "deb-src http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" >> /etc/apt/sources.list.d/nginx-stable-trusty.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C
-RUN apt-get update
-RUN apt-get install --only-upgrade bash
-RUN apt-get install -y  wget nginx
+RUN echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" > /etc/apt/sources.list.d/nginx-stable-trusty.list \
+ && echo "deb-src http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" >> /etc/apt/sources.list.d/nginx-stable-trusty.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C \
+ && apt-get update \
+ && apt-get install -y -q --no-install-recommends \
+    ca-certificates \
+    nginx \
+    wget \
+ && apt-get clean \
+ && rm -r /var/lib/apt/lists/*
 
-RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+# Configure Nginx and apply fix for long server names
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
+ && sed -i 's/# server_names_hash_bucket/server_names_hash_bucket/g' /etc/nginx/nginx.conf
 
-#fix for long server names
-RUN sed -i 's/# server_names_hash_bucket/server_names_hash_bucket/g' /etc/nginx/nginx.conf
-
-RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego
-RUN chmod u+x /usr/local/bin/forego
+ # Install Forego
+RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \
+ && chmod u+x /usr/local/bin/forego
 
 ENV DOCKER_GEN_VERSION 0.3.4
-RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
-RUN tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
 
-RUN mkdir /app
-WORKDIR /app
-ADD . /app
+RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
+ && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
+ && rm /docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
+
+COPY . /app/
+WORKDIR /app/
+
 
 EXPOSE 80
 ENV DOCKER_HOST unix:///tmp/docker.sock


### PR DESCRIPTION
This optimizes the Dockerfile by;
- Combining RUN statements so that files are removed in the
  same layer as they are added.
- Removing the downloaded .tar.gz of the docker-gen binary
  after expanding
- Adding `--no-install-recommends` (but explicitly installing
  ca-certificates)
- Replacing `ADD` with `COPY` (recommended if no unpacking is
  required)

Also added a `.dockerignore` file to prevent the `.git` directory
and README.md being added to the image.

These changes reduce the size of the image with 34 MB (was 268.4 MB,
now 233.9 MB), and results in less layers being produced.

Signed-off-by: Sebastiaan van Stijn github@gone.nl
