### PR TITLE
Switch to official nginx base-image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-FROM ubuntu:14.04
+FROM nginx:1.7
 MAINTAINER Jason Wilder jwilder@litl.com
 
-# Install Nginx.
-RUN echo "deb http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" > /etc/apt/sources.list.d/nginx-stable-trusty.list \
- && echo "deb-src http://ppa.launchpad.net/nginx/stable/ubuntu trusty main" >> /etc/apt/sources.list.d/nginx-stable-trusty.list \
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C \
- && apt-get update \
+# Install wget and install/updates certificates
+RUN apt-get update \
  && apt-get install -y -q --no-install-recommends \
     ca-certificates \
-    nginx \
     wget \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
@@ -30,7 +26,6 @@ RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VER
 COPY . /app/
 WORKDIR /app/
 
-EXPOSE 80 443
 ENV DOCKER_HOST unix:///tmp/docker.sock
 
 VOLUME ["/etc/nginx/certs"]

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 nginx: nginx
-dockergen: docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/sites-enabled/default
+dockergen: docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This changes the base-image to the official nginx image,
reducing the virtual size of the image by approx 50%.

As discussed in https://github.com/jwilder/nginx-proxy/pull/52

As far as I was able to tell, everything still works after switching the base-image.
