### PR TITLE
Removed VIRTUAL_PORT, now splits the VIRTUAL_HOST env on ':'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Provided your DNS is setup to forward foo.bar.com to the a host running nginx-pr
 
 ### Multiple Ports
 
-If your container exposes multiple ports, nginx-proxy will default to the service running on port 80.  If you need to specify a different port, you can set a VIRTUAL_PORT env var to select a different one.  If your container only exposes one port and it has a VIRTUAL_HOST env var set, that port will be selected.
+If your container exposes multiple ports, nginx-proxy will default to the service running on port 80.  If you need to specify a different port, you can add VIRTUAL_HOST as <host>:<port>. 
+
+    $ docker run -e VIRTUAL_HOST=foo.bar.com:8080  ...
+
+If your container only exposes one port and it has a VIRTUAL_HOST env var set, that port will be selected.
 
   [1]: https://github.com/jwilder/docker-gen
   [2]: http://jasonwilder.com/blog/2014/03/25/automated-nginx-reverse-proxy-for-docker/

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -49,7 +49,7 @@ upstream {{ $host }} {
 		   server {{ $address.IP }}:{{ $address.Port }};
 		{{ end }}
 	{{/* If more than one port exposed, use the one matching after the colon in VIRTUAL_HOST env var */}}
-	{{ else if $port }}
+	{{ else if (and ($port ) (ne $port $host) ) }}
 		{{ range $address := .Addresses }}
 		   {{ if eq $address.Port $port }}
 		   # {{$container.Name}}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -35,7 +35,9 @@ server {
 	return 503;
 }
 
-{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+{{ range $hostfull, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+{{ $host := first ( split $hostfull ":" ) }}
+{{ $port := last ( split $hostfull ":" ) }}
 
 upstream {{ $host }} {
 {{ range $container := $containers }}
@@ -46,10 +48,10 @@ upstream {{ $host }} {
 		   # {{$container.Name}}
 		   server {{ $address.IP }}:{{ $address.Port }};
 		{{ end }}
-	{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var */}}
-	{{ else if $container.Env.VIRTUAL_PORT }}
+	{{/* If more than one port exposed, use the one matching after the colon in VIRTUAL_HOST env var */}}
+	{{ else if $port }}
 		{{ range $address := .Addresses }}
-		   {{ if eq $address.Port $container.Env.VIRTUAL_PORT }}
+		   {{ if eq $address.Port $port }}
 		   # {{$container.Name}}
 		   server {{ $address.IP }}:{{ $address.Port }};
 		   {{ end }}


### PR DESCRIPTION
Sets port to the last element in the returned slice. 
Haven't thoroughly tested it but it works for my case with 2 sites on 2 different ports:

    docker run ... -e VIRTUAL_HOST=site1:80,site2:81 ...