### PR TITLE
Add $host to logs

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -14,7 +14,11 @@ map $http_upgrade $proxy_connection {
 
 gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
-access_log /proc/self/fd/1;
+log_format vhost '$host $remote_addr - $remote_user [$time_local] '
+                 '"$request" $status $body_bytes_sent '
+                 '"$http_referer" "$http_user_agent"';
+
+access_log /proc/self/fd/1 vhost;
 error_log /proc/self/fd/2;
 
 # HTTP 1.1 support


### PR DESCRIPTION
This change makes it possible to tell which lines in the `nginx-proxy` logs are coming in for which hosts.
