### PR TITLE
Bump to nginx 1.7.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.7.7
+FROM nginx:1.7.8
 MAINTAINER Jason Wilder jwilder@litl.com
 
 # Install wget and install/updates certificates


### PR DESCRIPTION
Nginx Inc added a new tag 1.7.8
https://github.com/nginxinc/docker-nginx/commit/04d0c5754673d6880b91e94c3cebaa767d9a1af7
