### PR TITLE
fixes problem to set server name max length…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
 
 # Configure Nginx and apply fix for long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/# server_names_hash_bucket/server_names_hash_bucket/g' /etc/nginx/nginx.conf
+ && sed -i 's/^http {/&\n    server_names_hash_bucket_size 64;/g' /etc/nginx/nginx.conf
 
  # Install Forego
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \


### PR DESCRIPTION
current base image (nginx:1.7.7) does not have commented configurations which means is impossible to use the previous configuration to set the server name max length
