### PR TITLE
Ability to set a default host for nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/^http {/&\n    server_names_hash_bucket_size 64;/g' /etc/nginx/nginx.conf
 
- # Install Forego
+# Install Forego
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \
  && chmod u+x /usr/local/bin/forego
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ If your container exposes multiple ports, nginx-proxy will default to the servic
 
 If you need to support multipe virtual hosts for a container, you can separate each entry with commas.  For example, `foo.bar.com,baz.bar.com,bar.com` and each host will be setup the same.
 
+### Default Host
+
+To set the default host for nginx use the env var `DEFAULT_HOST=foo.bar.com` for example
+
+    $ docker run -d -p 80:80 -e DEFAULT_HOST=foo.bar.com -v /var/run/docker.sock:/tmp/docker.sock jwilder/nginx-proxy
+
+
 ### Separate Containers
 
 nginx-proxy can also be run as two separate containers using the [jwilder/docker-gen](https://index.docker.io/u/jwilder/docker-gen/)

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -32,7 +32,7 @@ proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 
 server {
-	listen 80 default_server;
+	listen 80;
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
 	return 503;
 }
@@ -115,7 +115,16 @@ server {
 {{ else }}
 
 server {
-	server_name {{ $host }};
+	{{ if $.Env.DEFAULT_HOST }}
+	  {{ if eq $.Env.DEFAULT_HOST $host }}
+	    listen 80 default_server;
+	    server_name {{ $host }};
+	  {{ else }}
+	    server_name {{ $host }};
+          {{ end }}
+	{{ else }}
+	  server_name {{ $host }};
+	{{ end }}
 
 	location / {
 		proxy_pass http://{{ $host }};


### PR DESCRIPTION
When launching nginx-proxy you can use an env var to set which should be the default host header. If an env var is not defined then the default 503 will be returned. 

Closes #25