### PR TITLE
Set nginx client_max_body_size for containers exporting MAX_UPLOAD_SIZE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,12 @@ In order to be able to securize your virtual host, you have to create a file nam
     $ docker run -d -p 80:80 -p 443:443 -v /path/to/htpasswd:/etc/nginx/htpasswd -v /path/to/certs:/etc/nginx/certs -v /var/run/docker.sock:/tmp/docker.sock jwilder/nginx-proxy
 
 You'll need apache2-utils on the machine you plan to create de htpasswd file. Follow these [instructions](http://httpd.apache.org/docs/2.2/programs/htpasswd.html)
+
+### Setting the maximum upload size for a virtual host.
+
+Some virtual hosts may require upload sizes that are larger than the default nginx [client_max_body_size](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) of 1 MB.
+To achieve that, set the `MAX_UPLOAD_SIZE` variable on at least one of the containers that serve the `VIRTUAL_HOST`:
+
+    $ docker run -e VIRTUAL_HOST=foo.bar.com -e MAX_UPLOAD_SIZE=512m ...
+
+Please note that if a virtual host is served by multiple containers with conflicting values of `MAX_UPLOAD_SIZE` then only the first value will be used.

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -68,6 +68,9 @@ upstream {{ $host }} {
 {{ end }}
 }
 
+{{/* Get the first client max body size defined by containers w/ the same vhost */}}
+{{ $clientMaxBodySize := (first (groupByKeys $containers "Env.MAX_UPLOAD_SIZE")) }}
+
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
 
@@ -91,6 +94,11 @@ server {
 server {
 	server_name {{ $host }};
 	listen 443 ssl;
+
+	{{/* Set the Nginx client_max_body_size option from environment variables */}}
+	{{ if $clientMaxBodySize }}
+	client_max_body_size {{ $clientMaxBodySize }};
+	{{ end }}
 
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 	ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
@@ -116,6 +124,11 @@ server {
 
 server {
 	server_name {{ $host }};
+
+	{{/* Set the Nginx client_max_body_size option from environment variables */}}
+	{{ if $clientMaxBodySize }}
+	client_max_body_size {{ $clientMaxBodySize }};
+	{{ end }}
 
 	location / {
 		proxy_pass http://{{ $host }};


### PR DESCRIPTION
This PR is my minimal attempt at solving #29 and #39 .

It extends the nginx template to add exactly one `client_max_body_size` directive for each virtual host that export the `MAX_UPLOAD_SIZE` variable on at least one upstream container.