### PR TITLE
Allow for even longer virtual host names (should work to at least 50 chars).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
 
-# Configure Nginx and apply fix for long server names
+# Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/^http {/&\n    server_names_hash_bucket_size 64;/g' /etc/nginx/nginx.conf
+ && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
 
  # Install Forego
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \


### PR DESCRIPTION
Nginx complains when some containers export very long `VIRTUAL_HOST` (in my case 50 character long).

This error is painful because either:
 - nginx is already running when I start the container with long name: then nginx will silently keep using the old configuration and my new container and any container added after that won't be load-balanced.
 - the long name containers are running before nginx-proxy is started, then nginx-proxy will fail to start and no container will be load-balanced at all.

My workaround was to shorten the host name by setting `VIRTUAL_HOST=just-the-host-name.*`.

As better fix, this PR increases the nginx `server_names_hash_bucket_size` parameter to 128 (it was already increased from 32 to 64 in #9).