### PR TITLE
Gzip application/javascript

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -12,7 +12,7 @@ map $http_upgrade $proxy_connection {
   ''      '';
 }
 
-gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
 log_format vhost '$host $remote_addr - $remote_user [$time_local] '
                  '"$request" $status $body_bytes_sent '


### PR DESCRIPTION
As per RFC4329, nginx uses application/javascript as the default MIME
type for .js files. Nginx-proxy will now gzip these files if the client
requests it.