### PR TITLE
fixes SSL support while mixing HTTPS and non-HTTPS hosts

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -126,16 +126,16 @@ server {
 	}
 }
 
+{{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name {{ $host }};
 	listen 443 ssl;
 	return 503;
 
-	{{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;
-	{{ end }}
 }
+{{ end }}
 
 {{ end }}
 {{ end }}


### PR DESCRIPTION
nginx was throwing the following error: `no "ssl_certificate" is defined in server listening on SSL port while SSL handshaking`

fixes: https://github.com/jwilder/nginx-proxy/issues/74

the idea is to only create the 443 server if there is a default certificate available.