### PR TITLE
added rewrite for 'www'-prefixed requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,6 @@
 FROM nginx:1.7.8
 MAINTAINER https://m-ko-x.de Markus Kosmal <code@m-ko-x.de>
 
-# set max size within a body
-ENV GLOB_MAX_BODY_SIZE "10m"
-# set default msg set within basic auth msg
-ENV GLOB_AUTH_MSG "Restricted :"
-# set default session timeout
-ENV GLOB_SSL_SESSION_TIMEOUT "5m"
-# default return code for errors
-ENV GLOB_HTTP_NO_SERVICE "503"
-
-# enable some kind of prefix redirection
-ENV AUTO_REDIRECT_WITH_PREFIX_ENABLED false
-# set prefix to be used for auto redirect
-ENV AUTO_REDIRECT_PREFIX "www"
-# set direction
-# - 0: redirect from prefix to non-prefix
-# - 1: redirect from non-prefix to prefix
-ENV AUTO_REDIRECT_DIRECTION 0
-
 # install packages
 RUN apt-get update \
  && apt-get install -y -q --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,24 @@
 FROM nginx:1.7.8
 MAINTAINER https://m-ko-x.de Markus Kosmal <code@m-ko-x.de>
 
+# set max size within a body
+ENV GLOB_MAX_BODY_SIZE "10m"
+# set default msg set within basic auth msg
+ENV GLOB_AUTH_MSG "Restricted :"
+# set default session timeout
+ENV GLOB_SSL_SESSION_TIMEOUT "5m"
+# default return code for errors
+ENV GLOB_HTTP_NO_SERVICE "503"
+
+# enable some kind of prefix redirection
+ENV AUTO_REDIRECT_WITH_PREFIX_ENABLED false
+# set prefix to be used for auto redirect
+ENV AUTO_REDIRECT_PREFIX "www"
+# set direction
+# - 0: redirect from prefix to non-prefix
+# - 1: redirect from non-prefix to prefix
+ENV AUTO_REDIRECT_DIRECTION 0
+
 # install packages
 RUN apt-get update \
  && apt-get install -y -q --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
- && sed -i 's/^http {/&\n    client_max_body_size 10m;/g' /etc/nginx/nginx.conf 
+ && sed -i 's/#gzip  on;/&\n    client_max_body_size 10m;/g' /etc/nginx/nginx.conf 
  
  # Install Forego
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:1.7.8
-MAINTAINER Jason Wilder jwilder@litl.com
+MAINTAINER https://m-ko-x.de Markus Kosmal <code@m-ko-x.de>
 
-# Install wget and install/updates certificates
+# install packages
 RUN apt-get update \
  && apt-get install -y -q --no-install-recommends \
     ca-certificates \
@@ -12,7 +12,8 @@ RUN apt-get update \
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
-
+ && sed -i 's/^http {/&\n    client_max_body_size 10m;/g' /etc/nginx/nginx.conf 
+ 
  # Install Forego
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \
  && chmod u+x /usr/local/bin/forego

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
- && sed -i 's/#gzip  on;/&\n    client_max_body_size 10m;/g' /etc/nginx/nginx.conf 
  
  # Install Forego
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 ![nginx 1.7.8](https://img.shields.io/badge/nginx-1.7.8-brightgreen.svg) ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 
+##Modifications
+
+To make Jason's nginx-proxy work for me, I changed:
+
+- added rewrite of 'www'-prefixed domains to 301 without prefix for both https and http protocol
+
+##Original 
+
 nginx-proxy sets up a container running nginx and [docker-gen][1].  docker-gen generates reverse proxy configs for nginx and reloads nginx when containers are started and stopped.
 
 See [Automated Nginx Reverse Proxy for Docker][2] for why you might want to use this.

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -84,16 +84,19 @@ upstream {{ $host }} {
 {{ if (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
 server {
+    client_max_body_size 1000m;
     server_name  www.{{ $host }};
     rewrite ^(.*) https://{{ $host }}$1 permanent;
 }
 
 server {
+    client_max_body_size 1000m;
 	server_name {{ $host }};
 	rewrite ^(.*) https://{{ $host }}$1 permanent;
 }
 
 server {
+    client_max_body_size 1000m;
 	server_name {{ $host }};
 	listen 443 ssl;
 
@@ -120,11 +123,13 @@ server {
 {{ else }}
 
 server {
+    client_max_body_size 1000m;
     server_name  www.{{ $host }};
     rewrite ^(.*) http://{{ $host }}$1 permanent;
 }
 
 server {
+    client_max_body_size 1000m;
 	server_name {{ $host }};
 
 	location / {

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -21,6 +21,8 @@ log_format vhost '$host $remote_addr - $remote_user [$time_local] '
 access_log /proc/self/fd/1 vhost;
 error_log /proc/self/fd/2;
 
+client_max_body_size {{ "Env.MAX_BODY_SIZE" }};
+
 # HTTP 1.1 support
 proxy_http_version 1.1;
 proxy_buffering off;
@@ -34,7 +36,7 @@ proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 server {
 	listen 80 default_server;
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	return 503;
+	return "Env.GLOB_HTTP_NO_SERVICE";
 }
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
@@ -83,20 +85,34 @@ upstream {{ $host }} {
 
 {{ if (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
-server {
-    client_max_body_size 1000m;
-    server_name  www.{{ $host }};
-    rewrite ^(.*) https://{{ $host }}$1 permanent;
-}
+
+{{ if (eq "Env.AUTO_REDIRECT_WITH_PREFIX_ENABLED" true) }}
 
 server {
-    client_max_body_size 1000m;
+
+{{ if (eq "Env.AUTO_REDIRECT_DIRECTION" 0) }}
+
+    server_name  {{ "Env.AUTO_REDIRECT_PREFIX" }}.{{ $host }};
+    rewrite ^(.*) https://{{ $host }}$1 permanent;
+    
+{{ else }}
+
+    server_name {{ $host }};
+    rewrite ^(.*) https://{{ "Env.AUTO_REDIRECT_PREFIX" }}.{{ $host }}$1 permanent;
+    
+{{ end }} # AUTO_REDIRECT_DIRECTION end
+
+}
+
+{{ end }} # AUTO_REDIRECT_TARGET end
+
+# enforce ssl if enabled
+server {
 	server_name {{ $host }};
 	rewrite ^(.*) https://{{ $host }}$1 permanent;
 }
 
 server {
-    client_max_body_size 1000m;
 	server_name {{ $host }};
 	listen 443 ssl;
 
@@ -104,7 +120,7 @@ server {
 	ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
 
 	ssl_prefer_server_ciphers on;
-	ssl_session_timeout 5m;
+	ssl_session_timeout {{ "Env.GLOB_SSL_SESSION_TIMEOUT" }};
 	ssl_session_cache shared:SSL:50m;
 
 	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
@@ -115,27 +131,34 @@ server {
 	location / {
 		proxy_pass http://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
+		auth_basic	'{{ "Env.GLOB_AUTH_MSG" }} {{ $host }}';
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
 		{{ end }}
 	}
 }
 {{ else }}
 
-server {
-    client_max_body_size 1000m;
-    server_name  www.{{ $host }};
-    rewrite ^(.*) http://{{ $host }}$1 permanent;
-}
+{{ if (eq "Env.AUTO_REDIRECT_WITH_PREFIX_ENABLED" true) }}
 
 server {
-    client_max_body_size 1000m;
+    {{ if (eq "Env.AUTO_REDIRECT_DIRECTION" 0) }}
+    server_name  {{ "Env.AUTO_REDIRECT_PREFIX" }}.{{ $host }};
+    rewrite ^(.*) http://{{ $host }}$1 permanent;
+    {{ else }}
+    server_name {{ $host }};
+    rewrite ^(.*) http://{{ "Env.AUTO_REDIRECT_PREFIX" }}.{{ $host }}$1 permanent;
+    {{ end }} # AUTO_REDIRECT_DIRECTION end
+}
+
+{{ end }} # AUTO_REDIRECT_WITH_PREFIX_ENABLED end
+
+server {
 	server_name {{ $host }};
 
 	location / {
 		proxy_pass http://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
+		auth_basic	'{{ "Env.GLOB_AUTH_MSG" }} {{ $host }}';
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
 		{{ end }}
 	}
@@ -144,7 +167,7 @@ server {
 server {
 	server_name {{ $host }};
 	listen 443 ssl;
-	return 503;
+	return "Env.GLOB_HTTP_NO_SERVICE";
 
 	{{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 	ssl_certificate /etc/nginx/certs/default.crt;

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -21,8 +21,6 @@ log_format vhost '$host $remote_addr - $remote_user [$time_local] '
 access_log /proc/self/fd/1 vhost;
 error_log /proc/self/fd/2;
 
-client_max_body_size {{ "Env.MAX_BODY_SIZE" }};
-
 # HTTP 1.1 support
 proxy_http_version 1.1;
 proxy_buffering off;
@@ -36,7 +34,7 @@ proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 server {
 	listen 80 default_server;
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	return "Env.GLOB_HTTP_NO_SERVICE";
+	return 503;
 }
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
@@ -85,34 +83,20 @@ upstream {{ $host }} {
 
 {{ if (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
-
-{{ if (eq "Env.AUTO_REDIRECT_WITH_PREFIX_ENABLED" true) }}
-
 server {
-
-{{ if (eq "Env.AUTO_REDIRECT_DIRECTION" 0) }}
-
-    server_name  {{ "Env.AUTO_REDIRECT_PREFIX" }}.{{ $host }};
+    client_max_body_size 1000m;
+    server_name  www.{{ $host }};
     rewrite ^(.*) https://{{ $host }}$1 permanent;
-    
-{{ else }}
-
-    server_name {{ $host }};
-    rewrite ^(.*) https://{{ "Env.AUTO_REDIRECT_PREFIX" }}.{{ $host }}$1 permanent;
-    
-{{ end }} # AUTO_REDIRECT_DIRECTION end
-
 }
 
-{{ end }} # AUTO_REDIRECT_TARGET end
-
-# enforce ssl if enabled
 server {
+    client_max_body_size 1000m;
 	server_name {{ $host }};
 	rewrite ^(.*) https://{{ $host }}$1 permanent;
 }
 
 server {
+    client_max_body_size 1000m;
 	server_name {{ $host }};
 	listen 443 ssl;
 
@@ -120,7 +104,7 @@ server {
 	ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
 
 	ssl_prefer_server_ciphers on;
-	ssl_session_timeout {{ "Env.GLOB_SSL_SESSION_TIMEOUT" }};
+	ssl_session_timeout 5m;
 	ssl_session_cache shared:SSL:50m;
 
 	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
@@ -131,34 +115,27 @@ server {
 	location / {
 		proxy_pass http://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	'{{ "Env.GLOB_AUTH_MSG" }} {{ $host }}';
+		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
 		{{ end }}
 	}
 }
 {{ else }}
 
-{{ if (eq "Env.AUTO_REDIRECT_WITH_PREFIX_ENABLED" true) }}
-
 server {
-    {{ if (eq "Env.AUTO_REDIRECT_DIRECTION" 0) }}
-    server_name  {{ "Env.AUTO_REDIRECT_PREFIX" }}.{{ $host }};
+    client_max_body_size 1000m;
+    server_name  www.{{ $host }};
     rewrite ^(.*) http://{{ $host }}$1 permanent;
-    {{ else }}
-    server_name {{ $host }};
-    rewrite ^(.*) http://{{ "Env.AUTO_REDIRECT_PREFIX" }}.{{ $host }}$1 permanent;
-    {{ end }} # AUTO_REDIRECT_DIRECTION end
 }
 
-{{ end }} # AUTO_REDIRECT_WITH_PREFIX_ENABLED end
-
 server {
+    client_max_body_size 1000m;
 	server_name {{ $host }};
 
 	location / {
 		proxy_pass http://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	'{{ "Env.GLOB_AUTH_MSG" }} {{ $host }}';
+		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
 		{{ end }}
 	}
@@ -167,7 +144,7 @@ server {
 server {
 	server_name {{ $host }};
 	listen 443 ssl;
-	return "Env.GLOB_HTTP_NO_SERVICE";
+	return 503;
 
 	{{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 	ssl_certificate /etc/nginx/certs/default.crt;

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -84,6 +84,11 @@ upstream {{ $host }} {
 {{ if (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
 server {
+    server_name  www.{{ $host }};
+    rewrite ^(.*) https://{{ $host }}$1 permanent;
+}
+
+server {
 	server_name {{ $host }};
 	rewrite ^(.*) https://{{ $host }}$1 permanent;
 }
@@ -113,6 +118,11 @@ server {
 	}
 }
 {{ else }}
+
+server {
+    server_name  www.{{ $host }};
+    rewrite ^(.*) http://{{ $host }}$1 permanent;
+}
 
 server {
 	server_name {{ $host }};


### PR DESCRIPTION
After several users claiming not serving proxy via 'www'-prefixed URLs, added rewrite rule to template.