### PR TITLE
Per VIRTUAL_HOST configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,8 @@ For example, if you have a virtual host named `app.example.com`, you could provi
 
     $ docker run -d -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock jwilder/nginx-proxy
     $ { echo 'server_tokens off;'; echo 'client_max_body_size 100m;'; } > /path/to/vhost.d/app.example.com
+
+If you are using multiple hostnames for a single container (e.g. `VIRTUAL_HOST=example.com,www.example.com`), the virtual host configuration file must exist for each hostname. If you would like to use the same configuration for multiple virtual host names, you can use a symlink:
+
+    $ { echo 'server_tokens off;'; echo 'client_max_body_size 100m;'; } > /path/to/vhost.d/www.example.com
+    $ ln -s www.example.com /path/to/vhost.d/example.com

--- a/README.md
+++ b/README.md
@@ -130,18 +130,18 @@ FROM jwilder/nginx-proxy
 RUN { \
       echo 'server_tokens off;'; \
       echo 'client_max_body_size 100m;'; \
-    } > /etc/nginx/conf.d/my_custom_proxy.conf
+    } > /etc/nginx/conf.d/my_proxy.conf
 ```
 
 Or it can be done by mounting in your custom configuration in your `docker run` command:
 
-    $ docker run -d -p 80:80 -p 443:443 -v /path/to/my_custom_proxy.conf:/etc/nginx/conf.d/my_custom_proxy.conf:ro -v /var/run/docker.sock:/tmp/docker.sock jwilder/nginx-proxy
+    $ docker run -d -p 80:80 -p 443:443 -v /path/to/my_proxy.conf:/etc/nginx/conf.d/my_proxy.conf:ro -v /var/run/docker.sock:/tmp/docker.sock jwilder/nginx-proxy
 
 #### Per-VIRTUAL_HOST
 
 To add settings on a per-`VIRTUAL_HOST` basis, add your configuration file under `/etc/nginx/vhost.d`. Unlike in the proxy-wide case, which allows mutliple config files with any name ending in `.conf`, the per-`VIRTUAL_HOST` file must be named exactly after the `VIRTUAL_HOST`.
 
-In order to allow virtual hosts to be dynamically configured as backends are added and removed, it makes the most sense to mount an external directory as `/etc/nginx/vhost.d` as oppposed to using derived images or mounting individual configuration files.
+In order to allow virtual hosts to be dynamically configured as backends are added and removed, it makes the most sense to mount an external directory as `/etc/nginx/vhost.d` as opposed to using derived images or mounting individual configuration files.
 
 For example, if you have a virtual host named `app.example.com`, you could provide a custom configuration for that host as follows:
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -107,6 +107,10 @@ server {
 
 	add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
 
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	{{ end }}
+
 	location / {
 		proxy_pass {{ $proto }}://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -119,6 +123,10 @@ server {
 
 server {
 	server_name {{ $host }};
+
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	{{ end }}
 
 	location / {
 		proxy_pass {{ $proto }}://{{ $host }};


### PR DESCRIPTION
This PR adds the ability to configuration Nginx settings on a per `VIRTUAL_HOST` basis by adding a configuration file under `/etc/nginx/vhost.d`. As in the case of SSL configuration and basic authentication, the files in this directory are expected to be named after the `VIRTUAL_HOST` value verbatim (without `.conf`).

I also added some documentation around providing custom Nginx configuration on a proxy-wide basis. The whole README.md is starting to feel pretty messy to me, so it may make sense at some point to do an editing pass on it as a whole or to move large parts of it into wiki pages.

Fixes #29, #36, #39, #70, #76, #87 
Related #71 