### PR TITLE
Fix HTTP->HTTPS redirect for wildcard hosts

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -88,7 +88,7 @@ upstream {{ $host }} {
 
 server {
 	server_name {{ $host }};
-	rewrite ^(.*) https://{{ $host }}$1 permanent;
+	return 301 https://$host$request_uri;
 }
 
 server {


### PR DESCRIPTION
Uses Nginx's $host instead of interpolating `{{ $host }}` in the template

Refs #92 