### PR TITLE
Remove includeSubdomains from HSTS header

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -105,7 +105,7 @@ server {
 	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
 	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
 
-	add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+	add_header Strict-Transport-Security "max-age=31536000";
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};


### PR DESCRIPTION
includeSubdomains can lead to issues where not all subdomains are
able to use HTTPS.  This options might be too strict for the general
case: https://www.owasp.org/index.php/HTTP_Strict_Transport_Security.
It can be re-enabled w/ a custom template if needed.

Fixes #109