### PR TITLE
Add a default server for https

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -37,6 +37,12 @@ server {
 	return 503;
 }
 
+server {
+	listen 443 default_server;
+	server_name _;
+	return 503;
+}
+
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 
 upstream {{ $host }} {


### PR DESCRIPTION
When using nginx-proxy with https there's no default server, so the proxy passes request randomly to containers with different server name instead of showing a 503 error page.