### PR TITLE
Update to nginx:1.7.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.7.8
+FROM nginx:1.7.10
 MAINTAINER Jason Wilder jwilder@litl.com
 
 # Install wget and install/updates certificates


### PR DESCRIPTION
The latest `nginx` image is 1.7.10, so here's an update.

I'd probably be inclined to set this to `nginx:1.7` myself and set up a repository link on Docker Hub to trigger an automated build whenever `nginx:1.7` is updated, but I understand there are drawbacks to that approach.