### PR TITLE
Support static file serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,19 @@ If you are using multiple hostnames for a single container (e.g. `VIRTUAL_HOST=e
 
     $ { echo 'server_tokens off;'; echo 'client_max_body_size 100m;'; } > /path/to/vhost.d/www.example.com
     $ ln -s www.example.com /path/to/vhost.d/example.com
+
+### Static files serving
+
+In order to server static files in conjuction with reverse proxying the virtual host simply mount the static files directory to `/srv`
+
+For example, if you have a virtual host named `app.example.com`, you can server the static files from the host folder `/home/ubuntu/app/static` using:
+
+    $ docker run -d -p 80:80 -p 443:443 -v /srv/app.example.com:/home/ubuntu/app/static:ro -v /var/run/docker.sock:/tmp/docker.sock jwilder/nginx-proxy
+
+If you need to serve multiple hosts simply mount the /srv folder and use symlinks on the host:
+
+    $ mkdir -p /home/ubuntu/static
+    $ cd /home/ubuntu/static
+    $ ln -s app.example.com /home/ubuntu/app/static
+    $ ln -s app2.example.com /home/ubuntu/app2/static
+    $ docker run -d -p 80:80 -p 443:443 -v /srv:/home/ubuntu/static:ro -v /var/run/docker.sock:/tmp/docker.sock jwilder/nginx-proxy

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -138,7 +138,7 @@ server {
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
 	{{ end }}
 
-	@rev / {
+	location @rev {
 		proxy_pass {{ $proto }}://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -107,11 +107,16 @@ server {
 
 	add_header Strict-Transport-Security "max-age=31536000";
 
+    location / {
+        root /srv/{{ $host }};
+		try_files $uri/index.html $uri @rev;
+	}
+
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
 	{{ end }}
 
-	location / {
+	location @rev {
 		proxy_pass {{ $proto }}://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
@@ -124,11 +129,16 @@ server {
 server {
 	server_name {{ $host }};
 
+    location / {
+        root /srv/{{ $host }};
+		try_files $uri/index.html $uri @rev;
+	}
+
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
 	{{ end }}
 
-	location / {
+	@rev / {
 		proxy_pass {{ $proto }}://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";


### PR DESCRIPTION
Easy to use static file serving alongside the reverse proxy using the 'try_files' directive with named location technique