### PR TITLE
configure container as backup server

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ If your container exposes multiple ports, nginx-proxy will default to the servic
 
 If you need to support multiple virtual hosts for a container, you can separate each entry with commas.  For example, `foo.bar.com,baz.bar.com,bar.com` and each host will be setup the same.
 
+### Backup Server
+
+Sometimes it is necessary to mark a containers as [backup server](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server). To achieve this, set the environment variable `BACKUP_SERVER=true`.
+
 ### Wildcard Hosts
 
 You can also use wildcards at the beginning and the end of host name, like `*.bar.com` or `foo.bar.*`. Or even a regular expression, which can be very useful in conjunction with a wildcard DNS service like [xip.io](http://xip.io), using `~^foo\.bar\..*\.xip\.io` will match `foo.bar.127.0.0.1.xip.io`, `foo.bar.10.0.2.2.xip.io` and all other given IPs. More information about this topic can be found in the nginx documentation about [`server_names`](http://nginx.org/en/docs/http/server_names.html).

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -46,14 +46,14 @@ upstream {{ $host }} {
 	{{ if eq $addrLen 1 }}
 		{{ with $address := index $container.Addresses 0 }}
 		   # {{$container.Name}}
-		   server {{ $address.IP }}:{{ $address.Port }};
+		   server {{ $address.IP }}:{{ $address.Port }}{{if $container.Env.BACKUP_SERVER }} backup{{end}};
 		{{ end }}
 	{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var */}}
 	{{ else if $container.Env.VIRTUAL_PORT }}
 		{{ range $address := .Addresses }}
 		   {{ if eq $address.Port $container.Env.VIRTUAL_PORT }}
 		   # {{$container.Name}}
-		   server {{ $address.IP }}:{{ $address.Port }};
+		   server {{ $address.IP }}:{{ $address.Port }}{{if $container.Env.BACKUP_SERVER }} backup{{end}};
 		   {{ end }}
 		{{ end }}
 	{{/* Else default to standard web port 80 */}}
@@ -61,7 +61,7 @@ upstream {{ $host }} {
 		{{ range $address := $container.Addresses }}
 			{{ if eq $address.Port "80" }}
 			# {{$container.Name}}
-			server {{ $address.IP }}:{{ $address.Port }};
+			server {{ $address.IP }}:{{ $address.Port }}{{if $container.Env.BACKUP_SERVER }} backup{{end}};
 			{{ end }}
 		{{ end }}
 	{{ end }}


### PR DESCRIPTION
Hi Jason,

thank you very much for this awesome docker image.
I found out that it is not possible to configure a container as [backup server](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server).
I added this feature in this pull request.

have a nice day
Christoph