### PR TITLE
Close marker instead of empty

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -9,7 +9,7 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
 # Connection header that may have been passed to this server
 map $http_upgrade $proxy_connection {
   default upgrade;
-  ''      '';
+  '' close;
 }
 
 gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;


### PR DESCRIPTION
If a client is not providing the Upgrade HTTP header with the request, the connection will now be marked as 'to close' when finished.
See [#46](https://github.com/jwilder/nginx-proxy/pull/46) for more info.

Added a .gitignore by accident or out of habit as well.