### PR TITLE
Fix a couple things in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then start the docker-gen container with the shared volume and template:
 $ docker run --volumes-from nginx \
     -v /var/run/docker.sock:/tmp/docker.sock \
     -v $(pwd):/etc/docker-gen/templates \
-    -t docker-gen -notify-sighup nginx -watch -only-published /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    -t jwilder/docker-gen -notify-sighup nginx -watch -only-exposed /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
 ```
 
 Finally, start your containers with `VIRTUAL_HOST` environment variables.


### PR DESCRIPTION
As it is written, the "Separate Containers" section of the README doesn't work.  I added the jwilder repository to the docker-gen image name, assuming that the user won't have a local build named docker-gen, and also changed the docker-gen behavior from -only-published to -only-exposed, to match the nginx-proxy container's behavior.