### PR TITLE
Add support for ssl_dhparam to prevent 'Logjam' attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ hosts in use.  The certificate and keys should be named after the virtual host w
 #### Diffie-Hellman Groups
 
 If you have Diffie-Hellman groups enabled, the files should be named after the virtual host with a
-`dhparams` suffix and `.pem` extension. For example, a container with `VIRTUAL_HOST=foo.bar.com`
-should have a `foo.bar.com.dhparams.pem` file in the certs directory.
+`dhparam` suffix and `.pem` extension. For example, a container with `VIRTUAL_HOST=foo.bar.com`
+should have a `foo.bar.com.dhparam.pem` file in the certs directory.
 
 #### Wildcard Certificates
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ hosts in use.  The certificate and keys should be named after the virtual host w
 `.key` extension.  For example, a container with `VIRTUAL_HOST=foo.bar.com` should have a
 `foo.bar.com.crt` and `foo.bar.com.key` file in the certs directory.
 
+#### Diffie-Hellman Groups
+
+If you have Diffie-Hellman groups enabled, the files should be named after the virtual host with a
+`dhparams` suffix and `.pem` extension. For example, a container with `VIRTUAL_HOST=foo.bar.com`
+should have a `foo.bar.com.dhparams.pem` file in the certs directory.
+
 #### Wildcard Certificates
 
 Wildcard certificates and keys should be name after the domain name with a `.crt` and `.key` extension.

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -105,9 +105,9 @@ server {
 	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
 	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
 
-    {{ if (exists (printf "/etc/nginx/certs/%s.dhparams.pem" $cert)) }}
-    ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparams.pem" $cert }};
-    {{ end }}
+	{{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
+	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
+	{{ end }}
 
 	add_header Strict-Transport-Security "max-age=31536000";
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -105,6 +105,10 @@ server {
 	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
 	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
 
+    {{ if (exists (printf "/etc/nginx/certs/%s.dhparams.pem" $cert)) }}
+    ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparams.pem" $cert }};
+    {{ end }}
+
 	add_header Strict-Transport-Security "max-age=31536000";
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}


### PR DESCRIPTION
# Description
Added detection for DH group by site in the format ```<hostname>.dhparam.pem```, if file exists then use it.

# Reference 
* [The Logjam Attack](https://weakdh.org/)
* [Guide to Deploying Diffie-Hellman for TLS](https://weakdh.org/sysadmin.html)
* [CVE-2015-1716](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-1716)