### PR TITLE
Added in basic CORS support.

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -31,6 +31,11 @@ proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 
+proxy_pass_header Access-Control-Allow-Headers;
+proxy_pass_header Access-Control-Allow-Methods;
+proxy_pass_header Access-Control-Allow-Credentials;
+proxy_pass_header Access-Control-Allow-Origin;
+
 server {
 	listen 80;
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
@@ -117,6 +122,17 @@ server {
 
 	location / {
 		proxy_pass {{ $proto }}://{{ $host }};
+
+		if ({{"$"}}request_method = 'OPTIONS') {
+			add_header Access-Control-Allow-Origin '{{"$"}}http_origin';
+			add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
+			add_header Access-Control-Allow-Credentials 'true';
+			add_header Access-Control-Allow-Headers 'Origin,Content-Type,Accept';
+			add_header Content-Length 0;
+			add_header Content-Type text/plain;
+			return 204;
+		}
+
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
@@ -143,6 +159,17 @@ server {
 
 	location / {
 		proxy_pass {{ $proto }}://{{ $host }};
+
+		if ({{"$"}}request_method = 'OPTIONS') {
+			add_header Access-Control-Allow-Origin '{{"$"}}http_origin';
+			add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE';
+			add_header Access-Control-Allow-Credentials 'true';
+			add_header Access-Control-Allow-Headers 'Origin,Content-Type,Accept';
+			add_header Content-Length 0;
+			add_header Content-Type text/plain;
+			return 204;
+		}
+
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};


### PR DESCRIPTION
I've added a list of headers the proxy should allow to pass through so a server can respond to CORS requests. I've also made the proxy auto-respond to OPTIONS requests with a basic, pretty permissive CORS reply.

This won't support situations where the proxied server wishes to customise the OPTIONS reply.

Could do with something to allow customisation of allowed headers though.