### PR TITLE
Remove duplicate access log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update \
 
 # Configure Nginx and apply fix for very long server names
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
- && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
+ && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf \
+ && sed -i 's/access_log/#access_log/g' /etc/nginx/nginx.conf
 
 # Install Forego
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \


### PR DESCRIPTION
For each proxied request nginx-proxy currently logs:
```
nginx_1 | nginx.1    | 192.168.59.3 - - [15/Aug/2015:10:03:48 +0000] "GET / HTTP/1.1" 502 172 "-" "curl/7.37.1" "-"
nginx_1 | nginx.1    | test.tld 192.168.59.3 - - [15/Aug/2015:10:03:48 +0000] "GET / HTTP/1.1" 502 172 "-" "curl/7.37.1"
```

This PR removes the log line without hostname. Is there a good reason for keeping that access log? non-proxied requests somehow?