### PR TITLE
Fix for #188 - remove hostname from default SSL block

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -152,7 +152,7 @@ server {
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
-	server_name {{ $host }};
+	server_name _;
 	listen 443 ssl spdy {{ $default_server }};
 	return 503;
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -54,6 +54,17 @@ server {
 	return 503;
 }
 
+{{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
+server {
+	server_name _; # This is just an invalid value which will never trigger on a real hostname.
+	listen 443 ssl spdy;
+	return 503;
+
+	ssl_certificate /etc/nginx/certs/default.crt;
+	ssl_certificate_key /etc/nginx/certs/default.key;
+}
+{{ end }}
+
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 
 upstream {{ $host }} {
@@ -152,7 +163,7 @@ server {
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
-	server_name _;
+	server_name {{ $host }};
 	listen 443 ssl spdy {{ $default_server }};
 	return 503;
 


### PR DESCRIPTION
This resolves the issue where accessing a non-existent hostname over HTTPS returns the first SSL-enabled virtual host instead of correctly responding with a 503 error.