### PR TITLE
Added a higher client_max_body_size than standard

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,3 +1,5 @@
+client_max_body_size 200m;
+
 {{ define "upstream" }}
 	{{ if .Address }}
 		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}


### PR DESCRIPTION
This allows you to among other things upload images and files which are bigger than 1mb if you use nginx infront of wordpress