### PR TITLE
refuse to start if the docker sock isn't available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,4 @@ ENV DOCKER_HOST unix:///tmp/docker.sock
 VOLUME ["/etc/nginx/certs"]
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["nginx-proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ ENV DOCKER_HOST unix:///tmp/docker.sock
 
 VOLUME ["/etc/nginx/certs"]
 
-CMD ["forego", "start", "-r"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+if [[ $DOCKER_HOST == unix://* ]]; then
+	socket_file=${DOCKER_HOST#unix://}
+	if ! [ -S $socket_file ]; then
+		cat >&2 <<-EOT
+			ERROR: you need to share your docker host socket with a volume at $socket_file
+			Typically you should run your jwilder/nginx-proxy with: \`-v /var/run/docker.sock:$socket_file:ro\`
+			See documentation at http://git.io/vZaGJ
+		EOT
+		exit 1
+	fi
+fi
+
+exec forego start -r

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,16 +1,29 @@
 #!/bin/bash
 set -e
 
-if [[ $DOCKER_HOST == unix://* ]]; then
-	socket_file=${DOCKER_HOST#unix://}
-	if ! [ -S $socket_file ]; then
-		cat >&2 <<-EOT
-			ERROR: you need to share your docker host socket with a volume at $socket_file
-			Typically you should run your jwilder/nginx-proxy with: \`-v /var/run/docker.sock:$socket_file:ro\`
-			See documentation at http://git.io/vZaGJ
-		EOT
-		exit 1
+check_unix_socket() {
+	if [[ $DOCKER_HOST == unix://* ]]; then
+		socket_file=${DOCKER_HOST#unix://}
+		if ! [ -S $socket_file ]; then
+			cat >&2 <<-EOT
+				ERROR: you need to share your docker host socket with a volume at $socket_file
+				Typically you should run your jwilder/nginx-proxy with: \`-v /var/run/docker.sock:$socket_file:ro\`
+				See documentation at http://git.io/vZaGJ
+			EOT
+			exit 1
+		fi
 	fi
+}
+
+################################################################################
+
+# check for the expected command
+if [ "$1" = 'nginx-proxy' ]; then
+	check_unix_socket
+	exec forego start -r
 fi
 
-exec forego start -r
+# else default to run whatever the user wanted like "bash"
+exec "$@"
+
+


### PR DESCRIPTION
This PR implements a safeguard feature that will make the nginx-proxy container refuse to start if the `/tmp/docker.sock` socket isn't available _(or whatever unix socket file path given with `DOCKER_HOST`)_.

The intent is to reduce the number of support requests received such as #234 

When the docker socket isn't available, the container displays an explicit error message with a link to the _usage_ section of the README file.

Those changes where made following the [Docker Official Images](https://github.com/docker-library/official-images/blob/master/README.md) guidelines. And as such it adds a new behaviour to the image:

- when **no parameter** is passed to the container → **usual behavior**
- when **parameter `forego start -r`** is passed to the container → **usual behavior**
- **otherwise → run the command** given as parameter instead of the image entrypoint:

        $ docker run --rm -it jwilder/nginx-proxy echo Hi!
        Hi!

## tests

    docker build -t test .

### passing cases

    $ docker run --rm -t -v /var/run/docker.sock:/tmp/docker.sock:ro test
    forego     | starting nginx.1 on port 5000
    forego     | starting dockergen.1 on port 5100
    dockergen.1 | 2015/09/11 23:34:36 Generated '/etc/nginx/conf.d/default.conf' from 3 containers
    dockergen.1 | 2015/09/11 23:34:36 Running 'nginx -s reload'
    dockergen.1 | 2015/09/11 23:34:36 Watching docker events


    $ docker run --rm -t -e DOCKER_HOST=unix:///f00.sock -v /var/run/docker.sock:/f00.sock:ro test
    forego     | starting nginx.1 on port 5000
    forego     | starting dockergen.1 on port 5100
    dockergen.1 | 2015/09/11 23:34:04 Generated '/etc/nginx/conf.d/default.conf' from 2 containers
    dockergen.1 | 2015/09/11 23:34:04 Running 'nginx -s reload'
    dockergen.1 | 2015/09/11 23:34:04 Watching docker events


### safeguard in action

    $ docker run --rm -t test
    ERROR: you need to share your docker host socket with a volume at /tmp/docker.sock
    Typically you should run your jwilder/nginx-proxy with: `-v /var/run/docker.sock:/tmp/docker.sock:ro`
    See documentation at http://git.io/vZaGJ


    $ docker run --rm -t -e DOCKER_HOST=unix:///f00.sock test
    ERROR: you need to share your docker host socket with a volume at /f00.sock
    Typically you should run your jwilder/nginx-proxy with: `-v /var/run/docker.sock:/f00.sock:ro`
    See documentation at http://git.io/vZaGJ


    $ docker run --rm -t -e DOCKER_HOST=unix:///f00.sock -v /var/run/docker.sock:/tmp/docker.sock:ro test
    ERROR: you need to share your docker host socket with a volume at /f00.sock
    Typically you should run your jwilder/nginx-proxy with: `-v /var/run/docker.sock:/f00.sock:ro`
    See documentation at http://git.io/vZaGJ


### not `unix://`

    $ docker run --rm -t -e DOCKER_HOST=tcp://whatever test
    forego     | starting nginx.1 on port 5000
    forego     | starting dockergen.1 on port 5100
    dockergen.1 | 2015/09/11 23:46:24 Bad endpoint: Invalid bind address format: whatever
    forego     | starting dockergen.1 on port 5200
    forego     | sending SIGTERM to dockergen.1
    forego     | sending SIGTERM to nginx.1