### PR TITLE
add more descriptive error message when unix mount fails

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,6 +8,8 @@ if [[ $DOCKER_HOST == unix://* ]]; then
 		cat >&2 <<-EOT
 			ERROR: you need to share your Docker host socket with a volume at $socket_file
 			Typically you should run your jwilder/nginx-proxy with: \`-v /var/run/docker.sock:$socket_file:ro\`
+			If you are running your daemon over TLS, make sure you are also exposing it over a Unix socket
+			with the -H unix:///var/run/docker.sock argument
 			See the documentation at http://git.io/vZaGJ
 		EOT
 		socketMissing=1


### PR DESCRIPTION
Thought it might be helpful for people running into this issue to print this tip to users as well. I know it's been discussed in issues like https://github.com/jwilder/nginx-proxy/issues/113, but it took me a bit of digging to figure out this was actually the mistake I had made.
