### PR TITLE
CircleCI: make tests run on Docker 1.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ update-dependencies:
 	docker pull python:3
 	docker pull rancher/socat-docker:latest
 	docker pull appropriate/curl:latest
-	docker pull docker:1.7
+	docker pull docker:1.9
 
 test:
 	docker build -t jwilder/nginx-proxy:bats .

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   pre:
-    # install docker 1.7.1
-    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.7.1-circleci'; sudo chmod 0755 /usr/bin/docker; true
+    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'
+    - sudo chmod 0755 /usr/bin/docker
   services:
     - docker
 

--- a/test/lib/docker_helpers.bash
+++ b/test/lib/docker_helpers.bash
@@ -56,5 +56,5 @@ function docker_tcp {
 		--expose 2375 \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		rancher/socat-docker
-	docker run --link "$container_name:docker" docker:1.7 version
+	docker run --link "$container_name:docker" docker:1.9 version
 }


### PR DESCRIPTION
Since CircleCI now [supports docker 1.9.1](https://discuss.circleci.com/t/docker-1-9-1-is-available/1009)