### PR TITLE
turn off http to https redirect by setting SKIP_HTTPS_REDIR=true

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -109,12 +109,40 @@ upstream {{ $host }} {
 
 {{ if (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
+{{ $skipHttpsRedir := (first (groupByKeys $containers "Env.SKIP_HTTPS_REDIR")) }}
+{{ if not $skipHttpsRedir }}
 server {
 	server_name {{ $host }};
 	listen 80 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 	return 301 https://$host$request_uri;
 }
+{{ else }}
+server {
+        server_name {{ $host }};
+        listen 80 {{ $default_server }};
+        access_log /var/log/nginx/access.log vhost;
+
+        {{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+        include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+        {{ else if (exists "/etc/nginx/vhost.d/default") }}
+        include /etc/nginx/vhost.d/default;
+        {{ end }}
+
+        location / {
+                proxy_pass {{ trim $proto }}://{{ trim $host }};
+                {{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+                auth_basic      "Restricted {{ $host }}";
+                auth_basic_user_file    {{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+                {{ end }}
+                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+                include /etc/nginx/vhost.d/default_location;
+                {{ end }}
+        }
+}
+{{ end }}
 
 server {
 	server_name {{ $host }};


### PR DESCRIPTION
Potential fix for https://github.com/jwilder/nginx-proxy/issues/295

(Similar to a previous issue of mine: https://github.com/jwilder/nginx-proxy/issues/95)
