### PR TITLE
Support Overlay Network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \
  && chmod u+x /usr/local/bin/forego
 
-ENV DOCKER_GEN_VERSION 0.4.2
+ENV DOCKER_GEN_VERSION 0.5.0
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
 RUN wget -P /usr/local/bin https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego \
  && chmod u+x /usr/local/bin/forego
 
-ENV DOCKER_GEN_VERSION 0.5.0
+ENV DOCKER_GEN_VERSION 0.7.0
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ update-dependencies:
 	docker pull python:3
 	docker pull rancher/socat-docker:latest
 	docker pull appropriate/curl:latest
-	docker pull docker:1.9
+	docker pull docker:1.10
 
 test:
 	docker build -t jwilder/nginx-proxy:bats .

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [Automated Nginx Reverse Proxy for Docker][2] for why you might want to use 
 
 To run it:
 
-    $ docker run -d --net=host -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
 Then start any containers you want proxied with an env var `VIRTUAL_HOST=subdomain.youdomain.com`
 
@@ -33,6 +33,19 @@ If you need to support multiple virtual hosts for a container, you can separate 
 
 You can also use wildcards at the beginning and the end of host name, like `*.bar.com` or `foo.bar.*`. Or even a regular expression, which can be very useful in conjunction with a wildcard DNS service like [xip.io](http://xip.io), using `~^foo\.bar\..*\.xip\.io` will match `foo.bar.127.0.0.1.xip.io`, `foo.bar.10.0.2.2.xip.io` and all other given IPs. More information about this topic can be found in the nginx documentation about [`server_names`](http://nginx.org/en/docs/http/server_names.html).
 
+### Multiple Networks
+
+With the new overlay network, your proxy can be deal with many containers in many networks. Default, if you don't use ```--net``` flag, your proxy will be attached at ```bridge``` default network. You can define your container with ```--net=your_network``` option.
+
+If your proxy try to access at a container in an unattached network, the request is successful.
+
+#### Connect Another Network
+
+In current Docker release (1.9), you can create a container with only one network. To attach others networks, you can use this command.
+```
+docker network connect my_network my_container
+```
+
 ### SSL Backends
 
 If you would like to connect to your backend using HTTPS instead of HTTP, set `VIRTUAL_PROTO=https` on the backend container.
@@ -41,7 +54,7 @@ If you would like to connect to your backend using HTTPS instead of HTTP, set `V
 
 To set the default host for nginx use the env var `DEFAULT_HOST=foo.bar.com` for example
 
-    $ docker run -d --net=host -p 80:80 -e DEFAULT_HOST=foo.bar.com -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d -p 80:80 -e DEFAULT_HOST=foo.bar.com -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
 
 ### Separate Containers
@@ -56,13 +69,13 @@ To run nginx proxy as a separate container you'll need to have [nginx.tmpl](http
 First start nginx with a volume:
 
 
-    $ docker run -d --net=host -p 80:80 --name nginx -v /tmp/nginx:/etc/nginx/conf.d -t nginx
+    $ docker run -d -p 80:80 --name nginx -v /tmp/nginx:/etc/nginx/conf.d -t nginx
 
 Then start the docker-gen container with the shared volume and template:
 
 ```
 $ docker run --volumes-from nginx \
-    --net=host \
+    \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
     -v $(pwd):/etc/docker-gen/templates \
     -t jwilder/docker-gen -notify-sighup nginx -watch -only-exposed /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
@@ -79,7 +92,7 @@ certificates or optionally specifying a cert name (for SNI) as an environment va
 
 To enable SSL:
 
-    $ docker run -d --net=host -p 80:80 -p 443:443 -v /path/to/certs:/etc/nginx/certs -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d -p 80:80 -p 443:443 -v /path/to/certs:/etc/nginx/certs -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
 The contents of `/path/to/certs` should contain the certificates and private keys for any virtual
 hosts in use.  The certificate and keys should be named after the virtual host with a `.crt` and
@@ -128,7 +141,7 @@ In order to be able to secure your virtual host, you have to create a file named
 /etc/nginx/htpasswd/$VIRTUAL_HOST
 
 ```
-$ docker run -d --net=host -p 80:80 -p 443:443 \
+$ docker run -d -p 80:80 -p 443:443 \
     -v /path/to/htpasswd:/etc/nginx/htpasswd \
     -v /path/to/certs:/etc/nginx/certs \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
@@ -176,7 +189,7 @@ RUN { \
 
 Or it can be done by mounting in your custom configuration in your `docker run` command:
 
-    $ docker run -d --net=host -p 80:80 -p 443:443 -v /path/to/my_proxy.conf:/etc/nginx/conf.d/my_proxy.conf:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d -p 80:80 -p 443:443 -v /path/to/my_proxy.conf:/etc/nginx/conf.d/my_proxy.conf:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
 #### Per-VIRTUAL_HOST
 
@@ -186,7 +199,7 @@ In order to allow virtual hosts to be dynamically configured as backends are add
 
 For example, if you have a virtual host named `app.example.com`, you could provide a custom configuration for that host as follows:
 
-    $ docker run -d --net=host -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
     $ { echo 'server_tokens off;'; echo 'client_max_body_size 100m;'; } > /path/to/vhost.d/app.example.com
 
 If you are using multiple hostnames for a single container (e.g. `VIRTUAL_HOST=example.com,www.example.com`), the virtual host configuration file must exist for each hostname. If you would like to use the same configuration for multiple virtual host names, you can use a symlink:
@@ -206,7 +219,7 @@ just like the previous section except with the suffix `_location`.
 
 For example, if you have a virtual host named `app.example.com` and you have configured a proxy_cache `my-cache` in another custom file, you could tell it to use a proxy cache as follows:
 
-    $ docker run -d --net=host -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
     $ { echo 'proxy_cache my-cache;'; echo 'proxy_cache_valid  200 302  60m;'; echo 'proxy_cache_valid  404 1m;' } > /path/to/vhost.d/app.example.com_location
 
 If you are using multiple hostnames for a single container (e.g. `VIRTUAL_HOST=example.com,www.example.com`), the virtual host configuration file must exist for each hostname. If you would like to use the same configuration for multiple virtual host names, you can use a symlink:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [Automated Nginx Reverse Proxy for Docker][2] for why you might want to use 
 
 To run it:
 
-    $ docker run -d -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d --net=host -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
 Then start any containers you want proxied with an env var `VIRTUAL_HOST=subdomain.youdomain.com`
 
@@ -41,7 +41,7 @@ If you would like to connect to your backend using HTTPS instead of HTTP, set `V
 
 To set the default host for nginx use the env var `DEFAULT_HOST=foo.bar.com` for example
 
-    $ docker run -d -p 80:80 -e DEFAULT_HOST=foo.bar.com -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d --net=host -p 80:80 -e DEFAULT_HOST=foo.bar.com -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
 
 ### Separate Containers
@@ -56,12 +56,13 @@ To run nginx proxy as a separate container you'll need to have [nginx.tmpl](http
 First start nginx with a volume:
 
 
-    $ docker run -d -p 80:80 --name nginx -v /tmp/nginx:/etc/nginx/conf.d -t nginx
+    $ docker run -d --net=host -p 80:80 --name nginx -v /tmp/nginx:/etc/nginx/conf.d -t nginx
 
 Then start the docker-gen container with the shared volume and template:
 
 ```
 $ docker run --volumes-from nginx \
+    --net=host \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
     -v $(pwd):/etc/docker-gen/templates \
     -t jwilder/docker-gen -notify-sighup nginx -watch -only-exposed /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
@@ -78,7 +79,7 @@ certificates or optionally specifying a cert name (for SNI) as an environment va
 
 To enable SSL:
 
-    $ docker run -d -p 80:80 -p 443:443 -v /path/to/certs:/etc/nginx/certs -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d --net=host -p 80:80 -p 443:443 -v /path/to/certs:/etc/nginx/certs -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
 The contents of `/path/to/certs` should contain the certificates and private keys for any virtual
 hosts in use.  The certificate and keys should be named after the virtual host with a `.crt` and
@@ -127,7 +128,7 @@ In order to be able to secure your virtual host, you have to create a file named
 /etc/nginx/htpasswd/$VIRTUAL_HOST
 
 ```
-$ docker run -d -p 80:80 -p 443:443 \
+$ docker run -d --net=host -p 80:80 -p 443:443 \
     -v /path/to/htpasswd:/etc/nginx/htpasswd \
     -v /path/to/certs:/etc/nginx/certs \
     -v /var/run/docker.sock:/tmp/docker.sock:ro \
@@ -175,7 +176,7 @@ RUN { \
 
 Or it can be done by mounting in your custom configuration in your `docker run` command:
 
-    $ docker run -d -p 80:80 -p 443:443 -v /path/to/my_proxy.conf:/etc/nginx/conf.d/my_proxy.conf:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d --net=host -p 80:80 -p 443:443 -v /path/to/my_proxy.conf:/etc/nginx/conf.d/my_proxy.conf:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
 
 #### Per-VIRTUAL_HOST
 
@@ -185,7 +186,7 @@ In order to allow virtual hosts to be dynamically configured as backends are add
 
 For example, if you have a virtual host named `app.example.com`, you could provide a custom configuration for that host as follows:
 
-    $ docker run -d -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d --net=host -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
     $ { echo 'server_tokens off;'; echo 'client_max_body_size 100m;'; } > /path/to/vhost.d/app.example.com
 
 If you are using multiple hostnames for a single container (e.g. `VIRTUAL_HOST=example.com,www.example.com`), the virtual host configuration file must exist for each hostname. If you would like to use the same configuration for multiple virtual host names, you can use a symlink:
@@ -205,7 +206,7 @@ just like the previous section except with the suffix `_location`.
 
 For example, if you have a virtual host named `app.example.com` and you have configured a proxy_cache `my-cache` in another custom file, you could tell it to use a proxy cache as follows:
 
-    $ docker run -d -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
+    $ docker run -d --net=host -p 80:80 -p 443:443 -v /path/to/vhost.d:/etc/nginx/vhost.d:ro -v /var/run/docker.sock:/tmp/docker.sock:ro jwilder/nginx-proxy
     $ { echo 'proxy_cache my-cache;'; echo 'proxy_cache_valid  200 302  60m;'; echo 'proxy_cache_valid  404 1m;' } > /path/to/vhost.d/app.example.com_location
 
 If you are using multiple hostnames for a single container (e.g. `VIRTUAL_HOST=example.com,www.example.com`), the virtual host configuration file must exist for each hostname. If you would like to use the same configuration for multiple virtual host names, you can use a symlink:

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
 machine:
   pre:
-    - sudo curl -L -o /usr/bin/docker 'https://s3-external-1.amazonaws.com/circle-downloads/docker-1.9.1-circleci'
-    - sudo chmod 0755 /usr/bin/docker
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
   services:
     - docker
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,4 +1,4 @@
-{{ $CurrentContainer := where $ "ID" .CurrentContainerID | first }}
+{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
 
 {{ define "upstream" }}
 	{{ if .Address }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,3 +1,5 @@
+{{ $CurrentContainer := where $ "ID" .CurrentContainerID | first }}
+
 {{ define "upstream" }}
 	{{ if .Address }}
 		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
@@ -75,16 +77,24 @@ server {
 upstream {{ $host }} {
 {{ range $container := $containers }}
 	{{ $addrLen := len $container.Addresses }}
-	{{ $network := index $container.Networks 0 }}
-	{{/* If only 1 port exposed, use that */}}
-	{{ if eq $addrLen 1 }}
-		{{ $address := index $container.Addresses 0 }}
-		{{ template "upstream" (dict "Container" $container "Address" $address "Network" $network) }}
-	{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
-	{{ else }}
-		{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
-		{{ $address := where $container.Addresses "Port" $port | first }}
-		{{ template "upstream" (dict "Container" $container "Address" $address "Network" $network) }}
+
+	{{ range $knownNetwork := $CurrentContainer.Networks }}
+		{{ range $containerNetwork := $container.Networks }}
+			{{ if eq $knownNetwork.Name $containerNetwork.Name }}
+				## Can be connect with "{{ $containerNetwork.Name }}" network
+
+				{{/* If only 1 port exposed, use that */}}
+				{{ if eq $addrLen 1 }}
+					{{ $address := index $container.Addresses 0 }}
+					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+				{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
+				{{ else }}
+					{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
+					{{ $address := where $container.Addresses "Port" $port | first }}
+					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+				{{ end }}
+			{{ end }}
+		{{ end }}
 	{{ end }}
 {{ end }}
 }

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -5,13 +5,13 @@
 			# {{ .Container.Node.Name }}/{{ .Container.Name }}
 			server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
 		{{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
-		{{ else }}
+		{{ else if .Network }}
 			# {{ .Container.Name }}
-			server {{ .Address.IP }}:{{ .Address.Port }};
+			server {{ .Network.IP }}:{{ .Address.Port }};
 		{{ end }}
-	{{ else }}
+	{{ else if .Network }}
 		# {{ .Container.Name }}
-		server {{ .Container.IP }} down;
+		server {{ .Network.IP }} down;
 	{{ end }}
 {{ end }}
 
@@ -75,15 +75,16 @@ server {
 upstream {{ $host }} {
 {{ range $container := $containers }}
 	{{ $addrLen := len $container.Addresses }}
+	{{ $network := index $container.Networks 0 }}
 	{{/* If only 1 port exposed, use that */}}
 	{{ if eq $addrLen 1 }}
 		{{ $address := index $container.Addresses 0 }}
-		{{ template "upstream" (dict "Container" $container "Address" $address) }}
+		{{ template "upstream" (dict "Container" $container "Address" $address "Network" $network) }}
 	{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
 	{{ else }}
 		{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
 		{{ $address := where $container.Addresses "Port" $port | first }}
-		{{ template "upstream" (dict "Container" $container "Address" $address) }}
+		{{ template "upstream" (dict "Container" $container "Address" $address "Network" $network) }}
 	{{ end }}
 {{ end }}
 }

--- a/test/docker.bats
+++ b/test/docker.bats
@@ -73,6 +73,7 @@ load test_helpers
 		-v /var/run/docker.sock:/tmp/docker.sock:ro \
 		-v $BATS_TEST_DIRNAME/../nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro \
 		--volumes-from bats-nginx \
+		--expose 80 \
 		jwilder/docker-gen:0.7.0 \
 			-notify-sighup bats-nginx \
 			-watch \

--- a/test/docker.bats
+++ b/test/docker.bats
@@ -54,21 +54,15 @@ load test_helpers
 @test "[$TEST_FILE] separated containers (nginx + docker-gen + nginx.tmpl)" {
 	docker_clean bats-nginx
 	docker_clean bats-docker-gen
-	docker_network_clean bats-docker-gen-network
 
-	# MAKE network
-	run docker network create bats-docker-gen-network
-	assert_success
-	
 	# GIVEN a simple nginx container
 	run docker run -d \
 		--name bats-nginx \
-		--net=bats-docker-gen-network \
 		-v /etc/nginx/conf.d/ \
 		-v /etc/nginx/certs/ \
 		nginx:latest
 	assert_success
-	run retry 5 1s docker run --net=bats-docker-gen-network appropriate/curl --silent --fail --head http://$(docker_ips bats-nginx)/
+	run retry 5 1s docker run appropriate/curl --silent --fail --head http://$(docker_ip bats-nginx)/
 	assert_output -l 0 $'HTTP/1.1 200 OK\r'
 
 	# WHEN docker-gen runs on our docker host
@@ -95,7 +89,7 @@ load test_helpers
 		docker logs bats-docker-gen
 		false
 	} >&2
-	
+
 	# THEN
 	assert_nginxproxy_behaves bats-nginx
 }
@@ -120,4 +114,3 @@ function assert_nginxproxy_behaves {
 	run curl_container $container /data --header "Host: webFOO.bats" --head
 	assert_output -l 0 $'HTTP/1.1 503 Service Temporarily Unavailable\r'
 }
-

--- a/test/lib/docker_helpers.bash
+++ b/test/lib/docker_helpers.bash
@@ -62,5 +62,5 @@ function docker_tcp {
 		--expose 2375 \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		rancher/socat-docker
-	docker run --label bats-type="docker" --link "$container_name:docker" docker:1.9 version
+	docker run --label bats-type="docker" --link "$container_name:docker" docker:1.10 version
 }

--- a/test/lib/docker_helpers.bash
+++ b/test/lib/docker_helpers.bash
@@ -8,20 +8,9 @@ function docker_clean {
 	sleep .25s
 }
 
-# Removes network $1
-function docker_network_clean {
-	docker network rm $1 &>/dev/null ||:
-	sleep .25s
-}
-
 # get the ip of docker container $1
 function docker_ip {
 	docker inspect --format '{{ .NetworkSettings.IPAddress }}' $1
-}
-
-# get the ip of docker container $1
-function docker_ips {
-	docker inspect --format '{{ range .NetworkSettings.Networks }}{{ .IPAddress }}{{ end }}' $1
 }
 
 # get the running state of container $1

--- a/test/lib/docker_helpers.bash
+++ b/test/lib/docker_helpers.bash
@@ -8,9 +8,20 @@ function docker_clean {
 	sleep .25s
 }
 
+# Removes network $1
+function docker_network_clean {
+	docker network rm $1 &>/dev/null ||:
+	sleep .25s
+}
+
 # get the ip of docker container $1
 function docker_ip {
 	docker inspect --format '{{ .NetworkSettings.IPAddress }}' $1
+}
+
+# get the ip of docker container $1
+function docker_ips {
+	docker inspect --format '{{ range .NetworkSettings.Networks }}{{ .IPAddress }}{{ end }}' $1
 }
 
 # get the running state of container $1


### PR DESCRIPTION
- Migrate docker-gen from 0.4.2 to 0.5.0 (add []Network supports)
- Nginx template use now current IP into network.
- Documentation updated. Proxy must run it with the option --net=host to access at all differents networks (overlay network support - tested with ```docker-compose --x-networking up -d```)