### PR TITLE
Host an generated list of proxyfied sites

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 nginx: nginx
-dockergen: docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+gennginx: docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+genindex: docker-gen -watch -only-exposed /app/index.tmpl /usr/share/nginx/html/index.html

--- a/index.tmpl
+++ b/index.tmpl
@@ -1,0 +1,25 @@
+{{ $title := or $.Env.TITLE "List of proxied sites" }}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>{{ $title }}</title>
+  </head>
+  <body>
+  <!--<div class='titre' style='width:1500px'><h1>Reseau Mare Mais</h1></div>-->
+  <h1>{{ $title }}</h1>
+   <div>
+    <ul>
+    {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+      {{ range $container := $containers }}
+        {{if $container.Env.TITLE}}
+          <li><a href='http://{{ $container.Env.VIRTUAL_HOST  }}'>{{$container.Env.TITLE}}</a></li>
+        {{else}}
+          <li><a href='http://{{ $container.Env.VIRTUAL_HOST  }}'>{{$container.Env.VIRTUAL_HOST}}</a></li>
+        {{ end }}
+      {{ end }}
+    {{ end }}
+    </ul>
+   </div>
+  </body>
+</html>

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -55,7 +55,10 @@ server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
 	listen 80;
 	access_log /var/log/nginx/access.log vhost;
-	return 503;
+  location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+  }
 }
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
@@ -63,7 +66,10 @@ server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
 	listen 443 ssl http2;
 	access_log /var/log/nginx/access.log vhost;
-	return 503;
+  location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+  }
 
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -55,15 +55,35 @@ server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
 	listen 80;
 	access_log /var/log/nginx/access.log vhost;
+  return 503;
+}
+
+{{ if $.Env.INDEX_HOST }}
+server {
+	server_name {{$.Env.INDEX_HOST}}; # The local site
+	listen 80;
+	access_log /var/log/nginx/access.log vhost;
   location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
   }
 }
+{{ end }}
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
+	listen 443 ssl http2;
+	access_log /var/log/nginx/access.log vhost;
+  return 503;
+
+	ssl_certificate /etc/nginx/certs/default.crt;
+	ssl_certificate_key /etc/nginx/certs/default.key;
+}
+
+{{ if $.Env.INDEX_HOST }}
+server {
+	server_name {{$.Env.INDEX_HOST}}; # The local site
 	listen 443 ssl http2;
 	access_log /var/log/nginx/access.log vhost;
   location / {
@@ -74,6 +94,7 @@ server {
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;
 }
+{{ end }}
 {{ end }}
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}


### PR DESCRIPTION
Hello,

I wanted to have a dynamic list of the sites proxyfied by this container. And try to mockup it.

It will generate a index.html listing all the VIRTUAL_HOST from the container. It will use the content of env variable TITLE for each container to replace the link by something more useful.

I don't know either go and go templating and this may be not sufficient for all the cases adressed by origin, but I think it could be a nice-to-have feature to be enhanced by more specialized people.