### PR TITLE
Modifiy nginx.tmpl to allow both 443 and 80.

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -113,7 +113,28 @@ server {
 	server_name {{ $host }};
 	listen 80 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
+	{{ if (first (groupByKeys $containers "Env.ALLOW_80")) }}
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	{{ else if (exists "/etc/nginx/vhost.d/default") }}
+	include /etc/nginx/vhost.d/default;
+	{{ end }}
+
+	location / {
+		proxy_pass {{ trim $proto }}://{{ trim $host }};
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+		auth_basic	"Restricted {{ $host }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ end }}
+                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+                include /etc/nginx/vhost.d/default_location;
+                {{ end }}
+	}
+	{{ else }}
 	return 301 https://$host$request_uri;
+	{{ end }}
 }
 
 server {


### PR DESCRIPTION
Allow http when https is activated. This parameter avoid infinite redirect when the reverse proxy nginx-proxy is already behind another reverse proxy.

This parameter is not recommended for production. Use it for test / transition.

To use it, launch your container with the environnement variable ALLOW_80=1 :

    $ docker run -e VIRTUAL_HOST=foo.bar.com  ...