### PR TITLE
Try to understand CloudFront's forwarded-proto as well

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -22,6 +22,13 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
   ''      $scheme;
 }
 
+# If we received a HTTP-CloudFront-Forwarded-Proto, pass it through; otherwise,
+# pass along the original value.
+map $http_cloudfront_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_cloudfront_forwarded_proto;
+  ''      $proxy_x_forwarded_proto;
+}
+
 # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
 # Connection header that may have been passed to this server
 map $http_upgrade $proxy_connection {

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -17,7 +17,7 @@
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
 # scheme used to connect to this server
-map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+map $http_x_forwarded_proto $default_forwarded_proto {
   default $http_x_forwarded_proto;
   ''      $scheme;
 }
@@ -26,7 +26,7 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
 # pass along the original value.
 map $http_cloudfront_forwarded_proto $proxy_x_forwarded_proto {
   default $http_cloudfront_forwarded_proto;
-  ''      $proxy_x_forwarded_proto;
+  ''      $default_forwarded_proto;
 }
 
 # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any

--- a/test/default-host.bats
+++ b/test/default-host.bats
@@ -29,4 +29,12 @@ function setup {
 	# THEN querying the proxy with any other Host header → 200
 	run curl_container $SUT_CONTAINER / --head --header "Host: something.I.just.made.up"
 	assert_output -l 0 $'HTTP/1.1 200 OK\r'
+
+	# THEN querying the proxy with X-Forwarded-Proto → 200
+	run curl_container $SUT_CONTAINER / --head --header "X-Forwarded-Proto: https"
+	assert_output -l 0 $'HTTP/1.1 200 OK\r'
+
+	# THEN querying the proxy with HTTP-CloudFront-Forwarded-Proto → 200
+	run curl_container $SUT_CONTAINER / --head --header "HTTP-CloudFront-Forwarded-Proto: https"
+	assert_output -l 0 $'HTTP/1.1 200 OK\r'
 }


### PR DESCRIPTION
CloudFront specifically sends the "HTTP-CloudFront-Forwarded-Proto" header when dealing with `https`:
http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-headers-behavior
This PR aims to provide compatibility with this header, without these changes your app could land in a redirect loop.

The "HTTP-CloudFront-Forwarded-Proto" header tries to take precedence over the `X-Forwarded-Proto` when it exists.

The tests I added were for sanity; if we send the header, does nginx die? If we can make these tests better, like actually testing if it sets to `Proxy` headers correctly I'll happily adjust.

I realize something similar is possible to do with setting a custom `/etc/nginx/proxy.conf`, I noticed the `Proxy-X-Forwarded-Proto`+`HTTP-X-Forwarded-Proto` were supported so thought supporting this out of the box might be a nice addition as well. Feel free to close/ignore if you disagree :+1:
