### PR TITLE
Add SKIP_HSTS support

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -135,7 +135,9 @@ server {
 	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
 	{{ end }}
 
+	{{ if ne (coalesce (first (groupByKeys $containers "Env.SKIP_HSTS")) "") "1" }}
 	add_header Strict-Transport-Security "max-age=31536000";
+	{{ end }}
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};


### PR DESCRIPTION
Hi, is this useful to others? could it be done in a better way? if so i could fix it up, add tests, doc etc.
I would like to skip HSTS for a domain as it might be moved to another owner in the future.

Maybe better to make HSTS max-age configurable and if set to 0 just skip it?
