### PR TITLE
Fix for docker-compose v2 syntax

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -5,9 +5,12 @@
 			# {{ .Container.Node.Name }}/{{ .Container.Name }}
 			server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
 		{{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
-		{{ else }}
+		{{ else if .Address.IP }}
 			# {{ .Container.Name }}
 			server {{ .Address.IP }}:{{ .Address.Port }};
+		{{ else }}
+			# {{ .Container.Name }}
+			server {{ .Container.Name }}:{{ .Address.Port }};
 		{{ end }}
 	{{ else }}
 		# {{ .Container.Name }}


### PR DESCRIPTION
This PR solves #304 
Based on @duck1123 code

Notice: containers should be in same network. So, you may need to add `network_mode: 'bridge'` to every service in docker-compose.yml.