### PR TITLE
add env NO_HTTPS_AUTO_REDIRECT

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -91,6 +91,8 @@ upstream {{ $host }} {
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
 
+{{ $no_https_auto_redirect := or (first (groupByKeys $containers "Env.NO_HTTPS_AUTO_REDIRECT")) "false" }}
+
 {{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
 {{ $proto := or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http" }}
 
@@ -109,12 +111,43 @@ upstream {{ $host }} {
 
 {{ if (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
+{{ if ne $no_https_auto_redirect "true" }}
+
 server {
 	server_name {{ $host }};
 	listen 80 {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 	return 301 https://$host$request_uri;
 }
+
+{{ else }}
+
+server {
+	server_name {{ $host }};
+	listen 80 {{ $default_server }};
+	access_log /var/log/nginx/access.log vhost;
+
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	{{ else if (exists "/etc/nginx/vhost.d/default") }}
+	include /etc/nginx/vhost.d/default;
+	{{ end }}
+
+	location / {
+		proxy_pass {{ trim $proto }}://{{ trim $host }};
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+		auth_basic	"Restricted {{ $host }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ end }}
+                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+                include /etc/nginx/vhost.d/default_location;
+                {{ end }}
+	}
+}
+
+{{ end }}
 
 server {
 	server_name {{ $host }};


### PR DESCRIPTION
I did really need to this NO_HTTPS_AUTO_REDIRECT option.

When I leave a `http://blahblah` link in somewhere, nginx-proxy always redirect to https.
Then certification warning page of browser is show up annoyingly because my servers use self-signed certification yet.

To resolve this inconvenient situation, I added `NO_HTTPS_AUTO_REDIRECT` for only page doesn't need https. Docker containers using `-e NO_HTTPS_AUTO_REDIRECT=true` does not redirect to https automatically no more.