### PR TITLE
Updated docker-gen to version 0.7.1 (fixes CurrentContainerID empty issue)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
 ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
 RUN chmod u+x /usr/local/bin/forego
 
-ENV DOCKER_GEN_VERSION 0.7.0
+ENV DOCKER_GEN_VERSION 0.7.1
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \


### PR DESCRIPTION
Tested that this fixes the problem that I and many others have had due to an updated version of CoreOS. The underlying problem was a change in the way cgroups are represented in the file `/proc/self/cgroup`. This uses an updated version of `docker-gen` which can deal with new and old formats of this file.