### PR TITLE
Updates Readme on using Separate Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ docker run -d \
     -v $(pwd)/certs:/etc/nginx/certs:ro \
     -v $(pwd)/nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro \
     -t jwilder/docker-gen \
-        -notify-sighup nginx-proxy -wait 5s:30s -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+        -notify-sighup nginx-proxy -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
 ```
 
 Finally, start your containers with `VIRTUAL_HOST` environment variables.


### PR DESCRIPTION
- makes first command more readable
- adds name to docker-gen container
- adds volume for /etc/nginx/certs, which is needed by the latest .tmpl
- removes -only-exposed flag, it causes problems as discussed in issue #438