### PR TITLE
Disable HSTS when HTTPS_METHOD=noredirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,12 @@ a 503.
 
 To serve traffic in both SSL and non-SSL modes without redirecting to SSL, you can include the
 environment variable `HTTPS_METHOD=noredirect` (the default is `HTTPS_METHOD=redirect`).  You can also
-disable the non-SSL site entirely with `HTTPS_METHOD=nohttp`. Note that `HTTPS_METHOD` must be specified
-on each container for which you want to override the default behavior.
+disable the non-SSL site entirely with `HTTPS_METHOD=nohttp`. `HTTPS_METHOD` must be specified
+on each container for which you want to override the default behavior.  If `HTTPS_METHOD=noredirect` is
+used, Strict Transport Security (HSTS) is disabled to prevent HTTPS users from being redirected by the
+client.  If you cannot get to the HTTP site after changing this setting, your browser has probably cached
+the HSTS policy and is automatically redirecting you back to HTTPS.  You will need to clear your browser's
+HSTS cache or use an incognito window / different browser.
 
 ### Basic Authentication Support
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ a 503.
 
 To serve traffic in both SSL and non-SSL modes without redirecting to SSL, you can include the
 environment variable `HTTPS_METHOD=noredirect` (the default is `HTTPS_METHOD=redirect`).  You can also
-disable the non-SSL site entirely with `HTTPS_METHOD=nohttp`. 
+disable the non-SSL site entirely with `HTTPS_METHOD=nohttp`. Note that `HTTPS_METHOD` must be specified
+on each container for which you want to override the default behavior.
 
 ### Basic Authentication Support
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -153,7 +153,9 @@ server {
 	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
 	{{ end }}
 
+	{{ if (ne $https_method "noredirect") }}
 	add_header Strict-Transport-Security "max-age=31536000";
+	{{ end }}
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};

--- a/test/ssl.bats
+++ b/test/ssl.bats
@@ -56,6 +56,35 @@ function setup {
 	assert_200_https test.nginx-proxy.bats
 }
 
+@test "[$TEST_FILE] test SSL Strict-Transport-Security" {
+	# WHEN
+	prepare_web_container bats-ssl-hosts-4 "80 443" \
+		-e VIRTUAL_HOST=*.nginx-proxy.bats \
+		-e CERT_NAME=nginx-proxy.bats
+	dockergen_wait_for_event $SUT_CONTAINER start bats-ssl-hosts-1
+	sleep 1
+
+	# THEN
+	assert_301 test.nginx-proxy.bats
+	assert_200_https test.nginx-proxy.bats
+    assert_output -p "Strict-Transport-Security: max-age=31536000"
+}
+
+@test "[$TEST_FILE] test HTTPS_METHOD=noredirect disables Strict-Transport-Security" {
+	# WHEN
+	prepare_web_container bats-ssl-hosts-5 "80 443" \
+		-e VIRTUAL_HOST=*.nginx-proxy.bats \
+		-e CERT_NAME=nginx-proxy.bats \
+		-e HTTPS_METHOD=noredirect
+	dockergen_wait_for_event $SUT_CONTAINER start bats-ssl-hosts-3
+	sleep 1
+
+	# THEN
+	assert_200 test.nginx-proxy.bats
+	assert_200_https test.nginx-proxy.bats
+    refute_output -p "Strict-Transport-Security: max-age=31536000"
+}
+
 
 @test "[$TEST_FILE] stop all bats containers" {
 	stop_bats_containers


### PR DESCRIPTION
First, thanks to @palamccc for reporting this in #453.

When using `HTTP_METHOD=noredirect`, the user is essentially saying "don't automatically redirect my users from HTTP to HTTPS, however, users that end up at the HTTPS site are still being sent the HSTS header, which forces the client to redirect all HTTP requests to HTTPS.  My feeling is that HSTS should be removed when `HTTPS_METHOD=noredirect`.

I have implemented the change in this PR and added tests to cover the normal HSTS behavior and the `noredirect` behavior (after sifting through the bats docs for an hour before stumbling on `refute_output` :) ).

I've also expanded the documentation on `HTTPS_METHOD` as suggested in #446
