### PR TITLE
Mitigate httpoxy attack by suppressing `Proxy` request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,14 @@ proxy_set_header Connection $proxy_connection;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+
+# Mitigate httpoxy attack (see README for details)
 proxy_set_header Proxy "";
 ```
 
 ***NOTE***: If you provide this file it will replace the defaults; you may want to check the .tmpl file to make sure you have all of the needed options.
+
+***NOTE***: The default configuration blocks the `Proxy` HTTP request header from being sent to downstream servers.  This prevents attackers from using the so-called [httpoxy attack](http://httpoxy.org).  There is no legitimate reason for a client to send this header, and there are many vulnerable languages / platforms (`CVE-2016-5385`, `CVE-2016-5386`, `CVE-2016-5387`, `CVE-2016-5388`, `CVE-2016-1000109`, `CVE-2016-1000110`, `CERT-VU#797896`).
 
 #### Proxy-wide
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ proxy_set_header Connection $proxy_connection;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+proxy_set_header Proxy "";
 ```
 
 ***NOTE***: If you provide this file it will replace the defaults; you may want to check the .tmpl file to make sure you have all of the needed options.

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -51,6 +51,8 @@ proxy_set_header Connection $proxy_connection;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+
+# Mitigate httpoxy attack (see README for details)
 proxy_set_header Proxy "";
 {{ end }}
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -51,6 +51,7 @@ proxy_set_header Connection $proxy_connection;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+proxy_set_header Proxy "";
 {{ end }}
 
 server {


### PR DESCRIPTION
The so-called `httpoxy` attack [see httpoxy.org, CVE-2016-(5385-5388,1000109-1000110)] occurs when an errant client sends an HTTP `Proxy` request header.  This is non-standard, and no well-behaved client will send this header.  Many languages (PHP, Python, Golang), when used in a CGI scenario expose this header as an environment variable `HTTP_PROXY` in the CGI environment (as per the CGI spec).  Unfortunately, many server-side HTTP clients use that environment variable as the address of an outbound HTTP proxy, meaning an attacker can easily coerce a backend server to send private, internal HTTP traffic out to the public internet, to a destination of their choice.

This PR tells Nginx to suppress that header, and not forward it on to the backend servers.