### PR TITLE
Always generate config when starting container before forego

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,4 +19,7 @@ if [ "$socketMissing" = 1 -a "$1" = forego -a "$2" = start -a "$3" = '-r' ]; the
 	exit 1
 fi
 
+# Always generate config during startup
+docker-gen /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+
 exec "$@"


### PR DESCRIPTION
I recently encounter issue when removing SSL support for one of the containers, I simply removed the certificate key from the certs directory (removing files is not triggering the docker-gen). When container was restarted it failed to start with an error:

```
nginx.1    | 2016/08/09 12:52:35 [emerg] 48#48: BIO_new_file("/etc/nginx/certs/CERTIFICATE.crt") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/etc/nginx/certs/CERTIFICATE.crt','r') error:2006D080:BIO routines:BIO_new_file:no such file)
```

Nginx wasn't able to start because the file that I just removed was missing. This shouldn't happen as it was what I wanted to do (remove SSL support from the app). More strangely the forego didn't properly start the docker-gen command thus never updating the nginx configuration, which in result failed to start nginx in a loop:

```
root@ef214f81dc35:/app# forego start -r
forego     | starting nginx.1 on port 5000
forego     | starting dockergen.1 on port 5100
nginx.1    | 2016/08/09 12:54:03 [emerg] 28#28: BIO_new_file("/etc/nginx/certs/CERTIFICATE.crt") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/etc/nginx/certs/CERTIFICATE.crt','r') error:2006D080:BIO routines:BIO_new_file:no such file)
forego     | starting nginx.1 on port 5100
forego     | sending SIGTERM to dockergen.1
nginx.1    | 2016/08/09 12:54:03 [emerg] 36#36: BIO_new_file("/etc/nginx/certs/CERTIFICATE.crt") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/etc/nginx/certs/CERTIFICATE.crt','r') error:2006D080:BIO routines:BIO_new_file:no such file)
nginx.1    | nginx: [emerg] BIO_new_file("/etc/nginx/certs/CERTIFICATE.crt") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/etc/nginx/certs/CERTIFICATE.crt','r') error:2006D080:BIO routines:BIO_new_file:no such file)
forego     | sending SIGTERM to nginx.1
```

In order to fix that I had to either:
- bring back the certificate file, start nginx, stop the container that was using it, remove the files, start the container back again
- completly remove nginx container and start it up again with "fresh" config

Similiar issue may happen when there is a custom upstream configured inside nginx container which "depends" on a container which config was dynamically generated by docker-gen. If that container was stopped and nginx restarted, then we have very similiar issue.

In order to fix both of these issues, my proposition is to simply run docker-gen once before it reaches forego - then the nginx should start properly with freshly generated configuration.
