### PR TITLE
Add alpine base image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,31 @@
+FROM nginx:1.11.3-alpine
+MAINTAINER Jason Wilder mail@jasonwilder.com
+
+# Install wget and install/updates certificates
+RUN apk add --no-cache --virtual .run-deps \
+    ca-certificates bash wget \
+    && update-ca-certificates
+
+# Configure Nginx and apply fix for very long server names
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
+ && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
+
+# Install Forego
+ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
+RUN chmod u+x /usr/local/bin/forego
+
+ENV DOCKER_GEN_VERSION 0.7.3
+
+RUN wget --quiet https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
+ && tar -C /usr/local/bin -xvzf docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
+ && rm /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
+
+COPY . /app/
+WORKDIR /app/
+
+ENV DOCKER_HOST unix:///tmp/docker.sock
+
+VOLUME ["/etc/nginx/certs"]
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["forego", "start", "-r"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM nginx:1.11.3-alpine
+FROM nginx:1.11.8-alpine
 MAINTAINER Jason Wilder mail@jasonwilder.com
 
 # Install wget and install/updates certificates

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 update-dependencies:
 	docker pull jwilder/docker-gen:0.7.3
-	docker pull nginx:1.11.3
-	docker pull nginx:1.11.3-alpine
+	docker pull nginx:1.11.6
+	docker pull nginx:1.11.8-alpine
 	docker pull python:3
 	docker pull rancher/socat-docker:latest
 	docker pull appropriate/curl:latest

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 update-dependencies:
 	docker pull jwilder/docker-gen:0.7.3
 	docker pull nginx:1.11.3
+	docker pull nginx:1.11.3-alpine
 	docker pull python:3
 	docker pull rancher/socat-docker:latest
 	docker pull appropriate/curl:latest

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ update-dependencies:
 	docker pull appropriate/curl:latest
 	docker pull docker:1.10
 
-test:
+test-debian:
 	docker build -t jwilder/nginx-proxy:bats .
 	bats test
+
+test-alpine:
+	docker build -f Dockerfile.alpine -t jwilder/nginx-proxy:bats .
+	bats test
+
+test: test-debian test-alpine


### PR DESCRIPTION
Hi,

this PR adds a new alpine linux based version. 
Background: Nginx alpine ships with a newer openssl version and supports ALPN.

```
bash-4.3# nginx -V
nginx version: nginx/1.11.3
built by gcc 5.3.0 (Alpine 5.3.0)
built with OpenSSL 1.0.2h  3 May 2016
TLS SNI support enabled
```

I think it's better to keep the current nginx-proxy with debian and provide a second variant.

Try it: https://hub.docker.com/r/matthh/nginx-proxy/tags/

I simply created another automated build with "/Dockerfile.alpine" for "Dockerfile Location".
BTW: Different file sizes are amazing...

TODO:
- Create a new automated build with "alpine-latest" tag
- Add info to README
