### PR TITLE
do not enable HSTS for subdomains

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -158,7 +158,7 @@ server {
 	{{ end }}
 
 	{{ if (ne $https_method "noredirect") }}
-	add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+	add_header Strict-Transport-Security "max-age=31536000";
 	{{ end }}
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}


### PR DESCRIPTION
Before commit e95d3e9fdf7e8959b989f5868f555345274ad563 HSTS was only enabled for those FQDN that where managed by nginx-proxy - it did not bother the operation of any other subdomain. 

As the HSTS setting now includes subdomains a user is forced to provide all existing subdomains via HTTPS which might be not intended (i.e. https://domain.tld is serviced by nginx-proxy, non-related http://some.service.domain.tld is now forced to use HTTPS).

The PR reverts the behaviour to the former default.

It might be worth considering to introduce a ENV setting to _optionally_ enable `includeSubDomains`?
