### PR TITLE
Replace "replace" to "trimSuffix"

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -118,8 +118,8 @@ upstream {{ $host }} {
 {{ $vhostCert := (closest (dir "/etc/nginx/certs") (printf "%s.crt" $host))}}
 
 {{/* vhostCert is actually a filename so remove any suffixes since they are added later */}}
-{{ $vhostCert := replace $vhostCert ".crt" "" -1 }}
-{{ $vhostCert := replace $vhostCert ".key" "" -1 }}
+{{ $vhostCert := trimSuffix ".crt" $vhostCert }}
+{{ $vhostCert := trimSuffix ".key" $vhostCert }}
 
 {{/* Use the cert specified on the container or fallback to the best vhost match */}}
 {{ $cert := (coalesce $certName $vhostCert) }}


### PR DESCRIPTION
I have a domain key-mydomain.com. When I add domain www.key-mydomain.com with ssl cert I did not get the desired result. Function replace cut name ssl cert "www.key-mydomain.com.key" to "www-mydomain.com".