### PR TITLE
Added HTTPS_METHOD=nohttps to disable SSL site

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,13 @@ a 503.
 
 To serve traffic in both SSL and non-SSL modes without redirecting to SSL, you can include the
 environment variable `HTTPS_METHOD=noredirect` (the default is `HTTPS_METHOD=redirect`).  You can also
-disable the non-SSL site entirely with `HTTPS_METHOD=nohttp`. `HTTPS_METHOD` must be specified
-on each container for which you want to override the default behavior.  If `HTTPS_METHOD=noredirect` is
-used, Strict Transport Security (HSTS) is disabled to prevent HTTPS users from being redirected by the
-client.  If you cannot get to the HTTP site after changing this setting, your browser has probably cached
-the HSTS policy and is automatically redirecting you back to HTTPS.  You will need to clear your browser's
-HSTS cache or use an incognito window / different browser.
+disable the non-SSL site entirely with `HTTPS_METHOD=nohttp`, or disable the HTTPS site with 
+`HTTPS_METHOD=nohttps`. `HTTPS_METHOD` must be specified on each container for which you want to 
+override the default behavior.  If `HTTPS_METHOD=noredirect` is used, Strict Transport Security (HSTS) 
+is disabled to prevent HTTPS users from being redirected by the client.  If you cannot get to the HTTP 
+site after changing this setting, your browser has probably cached the HSTS policy and is automatically 
+redirecting you back to HTTPS.  You will need to clear your browser's HSTS cache or use an incognito 
+window / different browser.
 
 ### Basic Authentication Support
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -125,7 +125,7 @@ upstream {{ $host }} {
 {{/* Use the cert specified on the container or fallback to the best vhost match */}}
 {{ $cert := (coalesce $certName $vhostCert) }}
 
-{{ $is_https := (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
+{{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
 {{ if $is_https }}
 


### PR DESCRIPTION
This feature complements `HTTPS_METHOD=nohttp`, which disables the HTTP site.  For containers with `HTTPS_METHOD=nohttps` set, the template sets `is_https` to `false`, which treats everything as if there was no matching certificate.  

This solves issue #573, in which a user needs to disable the HTTPS site for a specific container with a subdomain that happens to match the SSL cert of another container.

A test has also been added to cover this directive.
