### PR TITLE
Increase limits for size of files that can be passed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get update \
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
 
+RUN { \
+    echo 'client_max_body_size 100M;'; \
+    } > /etc/nginx/conf.d/my_proxy.conf
+
 # Install Forego
 ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
 RUN chmod u+x /usr/local/bin/forego


### PR DESCRIPTION
I am using nginx-proxy to front for a series of Wordpress containers. Some of the content and themes on those sites exceeds the default limits for nginx - this change increases the size of what can be uploaded.
