### PR TITLE
fix crash when using end-of-string symbol `$` in regex VIRTUAL_HOST

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -85,8 +85,8 @@ server {
 {{ end }}
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
-
-upstream {{ $host }} {
+{{ $upstream_name := sha1 $host }}
+upstream {{ $upstream_name }} {
 {{ range $container := $containers }}
 	{{ $addrLen := len $container.Addresses }}
 
@@ -179,9 +179,9 @@ server {
 	location / {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $host }};
+		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $host }};
+		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
@@ -213,9 +213,9 @@ server {
 	location / {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $host }};
+		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $host }};
+		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -86,6 +86,7 @@ server {
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 {{ $upstream_name := sha1 $host }}
+# {{ $host }}
 upstream {{ $upstream_name }} {
 {{ range $container := $containers }}
 	{{ $addrLen := len $container.Addresses }}

--- a/test/wildcard-hosts.bats
+++ b/test/wildcard-hosts.bats
@@ -43,14 +43,28 @@ function setup {
 
 @test "[$TEST_FILE] VIRTUAL_HOST=~^foo\.bar\..*\.bats" {
 	# WHEN
-	prepare_web_container bats-wildcard-hosts-2 80 -e VIRTUAL_HOST=~^foo\.bar\..*\.bats
-	dockergen_wait_for_event $SUT_CONTAINER start bats-wildcard-hosts-2
+	prepare_web_container bats-wildcard-hosts-3 80 -e VIRTUAL_HOST=~^foo\.bar\..*\.bats
+	dockergen_wait_for_event $SUT_CONTAINER start bats-wildcard-hosts-3
 	sleep 1
 
 	# THEN
 	assert_200 foo.bar.whatever.bats
 	assert_200 foo.bar.why.not.bats
 	assert_200 foo.bar.why.not.bats-to-infinity-and-beyond
+	assert_503 unexpected.host.bats
+
+}
+
+@test "[$TEST_FILE] VIRTUAL_HOST=~^foo\.bar\..*\.bats$" {
+	# WHEN
+	prepare_web_container bats-wildcard-hosts-4 80 -e VIRTUAL_HOST=~^foo\.bar\..*\.bats$
+	dockergen_wait_for_event $SUT_CONTAINER start bats-wildcard-hosts-4
+	sleep 1
+
+	# THEN
+	assert_200 foo.bar.whatever.bats
+	assert_200 foo.bar.why.not.bats
+	assert_503 foo.bar.why.not.bats-to-infinity-and-beyond
 	assert_503 unexpected.host.bats
 
 }

--- a/test/wildcard-hosts.bats
+++ b/test/wildcard-hosts.bats
@@ -50,6 +50,7 @@ function setup {
 	# THEN
 	assert_200 foo.bar.whatever.bats
 	assert_200 foo.bar.why.not.bats
+	assert_200 foo.bar.why.not.bats-to-infinity-and-beyond
 	assert_503 unexpected.host.bats
 
 }


### PR DESCRIPTION
This PR adds tests to show a case where the nginx configuration file produced is not valid and makes nginx fail to reload.

----

`$ bats wildcard-hosts.bats`

    ✓ [wildcard-hosts] start a nginx-proxy container
    ✓ [wildcard-hosts] VIRTUAL_HOST=*.wildcard.bats
    ✓ [wildcard-hosts] VIRTUAL_HOST=wildcard.bats.*
    ✓ [wildcard-hosts] VIRTUAL_HOST=~^foo\.bar\..*\.bats
    ✗ [wildcard-hosts] VIRTUAL_HOST=~^foo\.bar\..*\.bats$
      (from function `assert_output' in file lib/bats/batslib.bash, line 328,
       from function `assert_200' in file wildcard-hosts.bats, line 83,
       in test file wildcard-hosts.bats, line 65)
        `assert_200 foo.bar.whatever.bats' failed
        HTTP/1.1 503 Service Temporarily Unavailable
      ab2531a8a276
      container_name: bats-wildcard-hosts-4
      ports: 80
      options: -e VIRTUAL_HOST=~^foo.bar..*.bats$
      expose_option: --expose=80


      -- line differs --
      index    : 0
      expected : HTTP/1.1 200 OK
      actual   : HTTP/1.1 503 Service Temporarily Unavailable
      --

    ✓ [wildcard-hosts] stop all bats containers

     tests, 1 failure

----

```
$ docker start bats-nginx-proxy-wildcard-hosts
$ docker start bats-wildcard-hosts-4
$ docker logs bats-nginx-proxy-wildcard-hosts
```

    dockergen.1 | 2017/01/07 22:48:10 Received event start for container 4aba463b7021
    dockergen.1 | 2017/01/07 22:48:11 Generated '/etc/nginx/conf.d/default.conf' from 2 containers
    dockergen.1 | 2017/01/07 22:48:11 Running 'nginx -s reload'
    dockergen.1 | 2017/01/07 22:48:11 Error running notify command: nginx -s reload, exit status 1


----

`$ docker exec bats-nginx-proxy-wildcard-hosts cat /etc/nginx/conf.d/default.conf`


    # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
    # scheme used to connect to this server
    map $http_x_forwarded_proto $proxy_x_forwarded_proto {
      default $http_x_forwarded_proto;
      ''      $scheme;
    }
    # If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
    # server port the client connected to
    map $http_x_forwarded_port $proxy_x_forwarded_port {
      default $http_x_forwarded_port;
      ''      $server_port;
    }
    # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
    # Connection header that may have been passed to this server
    map $http_upgrade $proxy_connection {
      default upgrade;
      '' close;
    }
    gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
    log_format vhost '$host $remote_addr - $remote_user [$time_local] '
                     '"$request" $status $body_bytes_sent '
                     '"$http_referer" "$http_user_agent"';
    access_log off;
    # HTTP 1.1 support
    proxy_http_version 1.1;
    proxy_buffering off;
    proxy_set_header Host $http_host;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection $proxy_connection;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
    proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
    # Mitigate httpoxy attack (see README for details)
    proxy_set_header Proxy "";
    server {
            server_name _; # This is just an invalid value which will never trigger on a real hostname.
            listen 80;
            access_log /var/log/nginx/access.log vhost;
            return 503;
    }
    upstream ~^foo.bar..*.bats$ {
                                    ## Can be connect with "bridge" network
                            # bats-wildcard-hosts-4
                            server 172.17.0.3:80;
    }
    server {
            server_name ~^foo.bar..*.bats$;
            listen 80 ;
            access_log /var/log/nginx/access.log vhost;
            location / {
                    proxy_pass http://~^foo.bar..*.bats$;
            }
    }
    
----

The issue is on one (or both) of those lines:

    upstream ~^foo.bar..*.bats$ {

    proxy_pass http://~^foo.bar..*.bats$;

If you remove the `$` from the regular expression, nginx is happy with the conf.