### PR TITLE
regexp: use sha1 for upstream only if regexp is used

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -92,7 +92,8 @@ server {
 {{ end }}
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
-{{ $upstream_name := sha1 $host }}
+{{ $is_regexp := hasPrefix "~" $host }}
+{{ $upstream_name := when $is_regexp (sha1 $host) $host }}
 # {{ $host }}
 upstream {{ $upstream_name }} {
 {{ range $container := $containers }}


### PR DESCRIPTION
Change a bit the new way to name upstream introduced in #671. With this PR, the new way to name upstreams is only triggered if matching hostname with a regular expression. 

The intent is to reduce changes to existing users who might have added custom conf to the vhost.d directory as discovered in #677