### PR TITLE
display error message in logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
 
 # Install Forego
-ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
-RUN chmod u+x /usr/local/bin/forego
+RUN wget --quiet -O- https://bin.equinox.io/a/aHZqYk1TwYN/forego-20170111202937-linux-amd64.tar.gz \
+    | tar xz -C /usr/local/bin/ \
+    && chmod u+x /usr/local/bin/forego
 
 ENV DOCKER_GEN_VERSION 0.7.3
 
@@ -24,6 +25,7 @@ RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VER
  && rm /docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
 
 COPY . /app/
+RUN chmod +x /app/*.sh
 WORKDIR /app/
 
 ENV DOCKER_HOST unix:///tmp/docker.sock

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -11,8 +11,9 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
  && sed -i 's/^http {/&\n    server_names_hash_bucket_size 128;/g' /etc/nginx/nginx.conf
 
 # Install Forego
-ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
-RUN chmod u+x /usr/local/bin/forego
+RUN wget --quiet -O- https://bin.equinox.io/a/aHZqYk1TwYN/forego-20170111202937-linux-amd64.tar.gz \
+    | tar xz -C /usr/local/bin/ \
+    && chmod u+x /usr/local/bin/forego
 
 ENV DOCKER_GEN_VERSION 0.7.3
 
@@ -21,6 +22,7 @@ RUN wget --quiet https://github.com/jwilder/docker-gen/releases/download/$DOCKER
  && rm /docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
 
 COPY . /app/
+RUN chmod +x /app/*.sh
 WORKDIR /app/
 
 ENV DOCKER_HOST unix:///tmp/docker.sock

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-dockergen: docker-gen -watch -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+dockergen: docker-gen -watch -notify "nginx -s reload" -notify-output /app/nginx.tmpl /etc/nginx/conf.d/default.conf
 nginx: nginx

--- a/dump.sh
+++ b/dump.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo
+echo "-------------------------------------------------------------------------------"
+find /etc/nginx/ -type f -name '*.conf' -o -path '/etc/nginx/vhost.d/*'
+echo
+echo "-------------------------------------------------------------------------------"
+find /etc/nginx/ -type f -name '*.conf' | while read config_file; do
+    echo "> $config_file"
+    awk '{printf "%3d %s\n", NR, $0}' "$config_file"
+done


### PR DESCRIPTION
The issue tracker is bloated with support requests. The intent of this PR is to reduce such requests by helping users help themselves.

One issue users frequently encounter is when `nginx -s reload` fails. In such case, no useful info about the actual issue can be found in the docker log.

In this PR, `docker-gen` is run with the `-notify-output` option and will now notify the `reload_nginx.sh` script. This script will run the `nginx -s reload` command, <s>and in case of failure dump the nginx config files to the docker logs</s>.

----

<s>As the forego binary downloaded from https://github.com/jwilder/forego/releases/download/v0.16.1/forego is missing [this](https://github.com/ddollar/forego/issues/51) fix, this PR embed a forego binary statically build from commit [c69a0e4](https://github.com/jwilder/forego/commit/c69a0e4a4a03bd618db22b2e740605eb361de9d3) (the HEAD of jwilder/forego@master).

Ideally, @jwilder would build a new binary and make it available as before.</s>
