### PR TITLE
First load docker-gen, then nginx

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-nginx: nginx
 dockergen: docker-gen -watch -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+nginx: nginx


### PR DESCRIPTION
This tiny change will prevent most of the recent issues I encountered using this image. 

## 1 - Restart loop when removing SSL key from already running container

To reproduce:
1) add ssl keys to proper directory
2) start a container A with VIRTUAL_HOST
3) nginx-proxy will create default.conf configuration properly
4) remove the ssl keys from directory
5) restart nginx proxy to refresh the configuration
6) nginx will be stuck in "restart" loop because it can't find the removed SSL key, which is in its configuration, since the first thing this image does is starting nginx instead of recreating configuration

This change will first generate configuration, then start the nginx, so it will update the default.conf to use it without ssl keys properly

## 2 - Restart loop when using containers in different networks while nginx proxy is not

To reproduce:
1) start nginx_proxy normally
2) add a container A with VIRTUAL_HOST and "net" which nginx_proxy is not a part of
3) at this moment nginx proxy will throw errors that nginx -s reload failed
4) restart nginx proxy
5) nginx will be stuck in "restart" loop with an error "no servers are inside upstream in /etc/nginx/conf.d/default.conf" - this makes sense because since nginx proxy is not in the same network as container A it can't see its IP so it can't properly generate the upstream block {}

While my change does not fix the upstream generation error it will at least ease up the way to get rid of that loop error, but either adding the nginx_proxy to proper network (while it is stopped) or stopping the A container and restarting the nginx_proxy service (doing that before my change was still causing the restart loop, because, like in Usecase 1 - the first thing container does is to start nginx, then update the configuration)

This is a different approach to #527 however this PR should pass tests (at least they do on my local machine)

