### PR TITLE
add a warning at the top of the config when `-only-exposed` is used with separated containers

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,5 +1,22 @@
 {{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
 
+{{/* When docker-gen is running from a separated container and with the
+	 -only-exposed (or -only-published) option, the template won't be provided
+	 with the current (docker-gen) container info, making $currentContainer `null`.
+*/}}
+{{ if not $CurrentContainer }}
+###############################################################################
+#                                                                             #
+#   Are you using using jwilder/nginx-proxy's nginx.tmpl with docker-gen      #
+#   running in a separated container?                                         #
+#                                                                             #
+#   Consider removing the docker-gen `-only-exposed` option and make sure     #
+#   the docker-gen container has access to the same networks as the nginx     #
+#   container.                                                                #
+#                                                                             #
+###############################################################################
+{{ end }}
+
 {{ define "upstream" }}
 	{{ if .Address }}
 		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}


### PR DESCRIPTION
add a warning at the top of the config when `-only-exposed` is used with separated containers. This will help all those users coming from [JrCs/docker-letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion) ending up having an empty `upstream` block in their nginx config.

In the template, one case where `$CurrentContainer` ends up being `null` is when you use the template from a separated container having no exposed port and you call the docker-gen process with the `-only-exposed` option.

If `$CurrentContainer` is null, the template won't find any reachable network to build the `upstream` block content.

----

Example compose file to reproduce the case:

    version: '2'

    networks:
      default: {}

    volumes:
      nginx_conf: {}
      nginx_certs: {}

    services:
      nginx:
        image: nginx
        container_name: nginx
        volumes:
          - nginx_conf:/etc/nginx/conf.d
          - nginx_certs:/etc/nginx/certs

      dockergen:
        image: jwilder/docker-gen
        command: -notify-sighup nginx -only-exposed -watch /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
        volumes_from:
          - nginx
        volumes:
          - /var/run/docker.sock:/tmp/docker.sock:ro
          - nginx_conf:/etc/nginx/conf.d
          - nginx_certs:/etc/nginx/certs
          - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl