### PR TITLE
Updated README to include HTTP/2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This image uses the debian:jessie based nginx image.
 
 #### jwilder/nginx-proxy:alpine
 
-This image is based on the nginx:alpine image.
+This image is based on the nginx:alpine image. Use this image to fully support HTTP/2 (including ALPN required by recent Chrome versions). A valid certificate is required as well (see eg. below "SSL Support using letsencrypt" for more info).
 
     $ docker pull jwilder/nginx-proxy:alpine
 


### PR DESCRIPTION
For really supporting HTTP 2.0 in modern browsers, the alpine image has to be used at the moment. The fact should be mentioned in the README to keep users from having to search (or worse create) issues.