### PR TITLE
Do not bind swarm mode's default 'ingress' overlay network as an upstream target

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -108,7 +108,7 @@ upstream {{ $upstream_name }} {
 
 	{{ range $knownNetwork := $CurrentContainer.Networks }}
 		{{ range $containerNetwork := $container.Networks }}
-			{{ if eq $knownNetwork.Name $containerNetwork.Name }}
+			{{ if (and (ne $containerNetwork.Name "ingress") (eq $knownNetwork.Name $containerNetwork.Name)) }}
 				## Can be connect with "{{ $containerNetwork.Name }}" network
 
 				{{/* If only 1 port exposed, use that */}}


### PR DESCRIPTION
When creating a docker swarm, docker creates and sets a default overlay network called 'ingress'. 

nginx-proxy inspects containers as they attach and because 'ingress' appears in each swarm-based container's attached networks it adds `ingress` as an upstream target in `nginx.tmpl`.

This is a problem if we use constraints to only run services on a given subset of containers. If all containers are not running the service, nginx-proxy will still attempt to dispatch to all containers on the ingress network and errors/timeouts occur when requests hit containers that are not running the services required.

Test setup of docker machines and the swarm:

``` bash
# Create a manager machine

docker-machine create --driver virtualbox --engine-label infra_role=manager manager-node-1

# Create some worker machines

docker-machine create --driver virtualbox --engine-label infra_role=worker worker-node-1
docker-machine create --driver virtualbox --engine-label infra_role=worker worker-node-2
docker-machine create --driver virtualbox --engine-label infra_role=worker worker-node-3

# Create a database machine

docker-machine create --driver virtualbox --engine-label infra_role=database database-node-1

# Set up the Swarm

SERVICE_IP=$(docker-machine ip manager-node-1)
eval $(docker-machine ssl manager-node-1)
docker swarm init --advertise-addr $SERVICE_IP --listen-addr $SERVICE_IP:2377
TOKEN=$(docker swarm join-token -q worker)
eval $(docker-machine ssl worker-node-1)
docker swarm join --token $TOKEN $SERVICE_IP:2377
eval $(docker-machine ssl worker-node-2)
docker swarm join --token $TOKEN $SERVICE_IP:2377
eval $(docker-machine ssl worker-node-3)
docker swarm join --token $TOKEN $SERVICE_IP:2377
eval $(docker-machine ssl database-node-1)
docker swarm join --token $TOKEN $SERVICE_IP:2377
```

docker-compose.yml
``` yaml
version: '2'
services:
  nginx-proxy:
    image: jwilder/nginx-proxy
    container_name: nginx-proxy
    ports:
      - "80:80"
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro
    networks: 
      - nginx-proxy
    deploy:
      mode: global
      placement:
        constraints: [engine.labels.infra_role == worker]

  whoami_1:
    image: jwilder/whoami
    ports:
      - 8081:8080
    environment:
      - VIRTUAL_HOST=whoami-1.local
    networks: 
      - nginx-proxy
      - mysql
    deploy:
      mode: global
      placement:
        constraints: [engine.labels.infra_role == worker]

  whoami_2:
    image: jwilder/whoami
    ports:
      - 8082:8080
    environment:
      - VIRTUAL_HOST=whoami-2.local
    networks: 
      - nginx-proxy
      - mysql
    deploy:
      mode: global
      placement:
        constraints: [engine.labels.infra_role == worker]

    db:
      image: mysql:5.7
      networks: 
        - mysql
      environment:
        MYSQL_ROOT_PASSWORD: change_me
      deploy:
        mode: global
        placement:
          constraints: [engine.labels.infra_role == database]

networks:
  nginx-proxy:
  mysql:
```

Finally, create a new service stack with the above machines + docker-compose file:

    eval $(docker-machine ssl manager-node-1)
    docker stack deploy -c docker-compose.yml my_service

At this point, the upstreams in the `/etc/nginx/conf.d/default.conf` files in each of the 3 infra_role=worker containers will look as follows:

```
upstream whoami-1.local {
    ## Can be connect with "ingress" network
    server 10.0.0.3:8081
    ## Can be connect with "nginx-proxy" network
    server 10.0.0.10:8081
}

upstream whoami-2.local {
    ## Can be connect with "ingress" network
    server 10.0.0.3:8082
    ## Can be connect with "nginx-proxy" network
    server 10.0.0.10:8082
}
```

When nginx then tries to dispatch an upstream call to one of the ingress addresses (`10.0.0.3:8081` or `10.0.0.3:8082`) it will **also include the `database-node-1` machine in that dispatching** which is _not_ running the required services. **Therefore 1 in every 3 requests being made to nginx-proxy will fail or timeout.**

This PR thus simply disables the addition of 'ingress' to the upstream targets in nginx.tmpl for all virtual hosts to avoid this issue occurring.

This PR makes the upstream blocks look as follows:

```
upstream whoami-1.local {
    ## Can be connect with "nginx-proxy" network
    server 10.0.0.10:8081
}

upstream whoami-2.local {
    ## Can be connect with "nginx-proxy" network
    server 10.0.0.10:8082
}
```

Which fixes the issue!

Please let me know if you need any more info. The example files shown above are included only to provide an explanation of what is happening rather than heavily tested as working code.