### PR TITLE
support fastcgi

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ If you would like to connect to uWSGI backend, set `VIRTUAL_PROTO=uwsgi` on the
 backend container. Your backend container should then listen on a port rather
 than a socket and expose that port.
 
+### FastCGI Backends
+ 
+If you would like to connect to FastCGI backend, set `VIRTUAL_PROTO=fastcgi` on the
+backend container. Your backend container should then listen on a port rather
+than a socket and expose that port.
+ 
+### FastCGI Filr Root Directory
+
+If you use fastcgi,you can set `VIRTUAL_ROOT=xxx`  for your root directory
+
+
 ### Default Host
 
 To set the default host for nginx use the env var `DEFAULT_HOST=foo.bar.com` for example

--- a/README.md
+++ b/README.md
@@ -108,16 +108,6 @@ If you would like to connect to uWSGI backend, set `VIRTUAL_PROTO=uwsgi` on the
 backend container. Your backend container should then listen on a port rather
 than a socket and expose that port.
 
-### FastCGI Backends
-
-If you would like to connect to FastCGI backend, set `VIRTUAL_PROTO=fastcgi` on the
-backend container. Your backend container should then listen on a port rather
-than a socket and expose that port.
-
-### FastCGI Filr Root Directory
-
-If you use fastcgi,you can set `VIRTUAL_ROOT=xxx`  for your root directory
-
 ### Default Host
 
 To set the default host for nginx use the env var `DEFAULT_HOST=foo.bar.com` for example

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ If you would like to connect to uWSGI backend, set `VIRTUAL_PROTO=uwsgi` on the
 backend container. Your backend container should then listen on a port rather
 than a socket and expose that port.
 
+### FastCGI Backends
+
+If you would like to connect to FastCGI backend, set `VIRTUAL_PROTO=fastcgi` on the
+backend container. Your backend container should then listen on a port rather
+than a socket and expose that port.
+
+### FastCGI Filr Root Directory
+
+If you use fastcgi,you can set `VIRTUAL_ROOT=xxx`  for your root directory
+
 ### Default Host
 
 To set the default host for nginx use the env var `DEFAULT_HOST=foo.bar.com` for example

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -146,6 +146,10 @@ upstream {{ $upstream_name }} {
 {{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
 {{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
 
+{{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
+{{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
+
+
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
 
@@ -212,6 +216,10 @@ server {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ else if eq $proto "fastcgi" }}
+		root   {{ trim $vhost_root }};
+		include fastcgi.conf;
+		fastcgi_pass {{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
@@ -250,6 +258,10 @@ server {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ else if eq $proto "fastcgi" }}
+		root   {{ trim $vhost_root }};
+		include fastcgi.conf;
+		fastcgi_pass {{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -146,10 +146,6 @@ upstream {{ $upstream_name }} {
 {{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
 {{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
 
-{{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
-{{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
-
-
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
 
@@ -216,10 +212,6 @@ server {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ else if eq $proto "fastcgi" }}
-		root   {{ trim $vhost_root }};
-		include fastcgi.conf;
-		fastcgi_pass {{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
@@ -258,10 +250,6 @@ server {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
-		{{ else if eq $proto "fastcgi" }}
-		root   {{ trim $vhost_root }};
-		include fastcgi.conf;
-		fastcgi_pass {{ trim $upstream_name }};
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}


### PR DESCRIPTION
Demo
~~~
version: '2'
services:
  nginx-proxy:
    image: qiqizjl/nginx-proxy
    container_name: nginx-proxy
    ports:
      - "81:80"
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock:ro

  php-fpm:
    image: php:fpm-alpine
    environment:
      - VIRTUAL_HOST=php-fpm.local
      - VIRTUAL_ROOT=/var/www/html
      - VIRTUAL_PORT=9000
      - VIRTUAL_PROTO=fastcgi
~~~