### PR TITLE
Fallback if container has no IP

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -13,8 +13,13 @@
 		{{ end }}
 	{{ else if .Network }}
 		# {{ .Container.Name }}
-		server {{ .Network.IP }} down;
+		{{ if .Network.IP }}
+			server {{ .Network.IP }} down;
+		{{ else }}
+			server 127.0.0.1 down;
+		{{ end }}
 	{{ end }}
+	
 {{ end }}
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the


### PR DESCRIPTION
Sometimes containers will not be assigned an IP (after reboot or due to misconfiguration). This leads to an incorrect `server <missing ip here> down;` line in default.conf and crashes nginx. 
@therealgambo provided a fix for this: #845 