### PR TITLE
Added support for IPv6 DNS servers in resolver generation (issue #938)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,8 +18,8 @@ fi
 # Note: if $DHPARAM_BITS is not defined, generate-dhparam.sh will use 2048 as a default
 /app/generate-dhparam.sh $DHPARAM_BITS
 
-# Compute the DNS resolvers for use in the templates
-export RESOLVERS=$(awk '$1 == "nameserver" {print $2}' ORS=' ' /etc/resolv.conf | sed 's/ *$//g')
+# Compute the DNS resolvers for use in the templates - if the IP contains ":", it's IPv6 and must be enclosed in []
+export RESOLVERS=$(awk '$1 == "nameserver" {print ($2 ~ ":")? "["$2"]": $2}' ORS=' ' /etc/resolv.conf | sed 's/ *$//g')
 if [ "x$RESOLVERS" = "x" ]; then
     echo "Warning: unable to determine DNS resolvers for nginx" >&2
     unset RESOLVERS


### PR DESCRIPTION
Bugfix for #938

Currently, if there are IPv6 nameservers in `/etc/resolv.conf`, they are not properly formatted when they are inserted into the Nginx template.  Nginx requires them to be surrounded by `[]` like `[2a02::1:1]`

This PR assumes all IPv6 addresses contain a colon character `:` (which I believe to be true), and surrounds them with square brackets before passing them to Nginx.

@pupssman - I've pushed this branch to my repo at `kamermans/nginx-proxy:bugfix_ipv6_resolvers` (built from `master`) - can you please give it a spin to make sure it works ok in your environment?  It's working fine here, but I don't have IPv6 support in my test environment, so I would feel better if it was tested properly.