### PR TITLE
Add VIRTUAL_GROUP container filtering and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ When internal-only access is enabled, external clients with be denied with an `H
 
 > If there is a load-balancer / reverse proxy in front of `nginx-proxy` that hides the client IP (example: AWS Application/Elastic Load Balancer), you will need to use the nginx `realip` module (already installed) to extract the client's IP from the HTTP request headers.  Please see the [nginx realip module configuration](http://nginx.org/en/docs/http/ngx_http_realip_module.html) for more details.  This configuration can be added to a new config file and mounted in `/etc/nginx/conf.d/`.
 
+### Proxy Groups
+
+You can limit proxy services to a specific group of containers. Setting
+the env var VIRTUAL_GROUP on a nginx-proxy container to an arbitrary name
+will restrict it to servicing only containers having an env var VIRTUAL_GROUP
+with the same name. Unlike Local Network Access or other restrictions,
+groups restrict what a nginx-proxy instance knows about other virtual hosts.
+
+Consider a docker host running two nginx-proxy containers; one for public
+services and another for publicly acessible, secured "backend" services. By
+default, both proxy servers will contain directives (e.g. `upstream`,
+`server`, etc.) for all virtual hosts. Defining two groups `PUBLIC`
+and `BACKEND` and applying them to their respective nginx-proxy instance
+and virtual hosts ensures that each proxy server only knows about and
+serves their intended virtual hosts.
+
+> Grouping only affects nginx-proxy configurations. Each nginx-proxy must
+still be attached to appropriate networks to access containers for which
+they are proxies.
+
 ### SSL Backends
 
 If you would like the reverse proxy to connect to your backend using HTTPS instead of HTTP, set `VIRTUAL_PROTO=https` on the backend container.

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -110,7 +110,10 @@ server {
 }
 {{ end }}
 
-{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+{{/* Filter containers by VIRTUAL_GROUP, if set; otherwise use all containers */}}
+{{ $vgrp := or $.Env.VIRTUAL_GROUP "" }}
+{{ $filtered := or (where $ "Env.VIRTUAL_GROUP" $vgrp) $ }}
+{{ range $host, $containers := groupByMulti $filtered "Env.VIRTUAL_HOST" "," }}
 
 {{ $host := trim $host }}
 {{ $is_regexp := hasPrefix "~" $host }}


### PR DESCRIPTION
Unlike PR #343, this PR adds a simpler mechanism to optionally create proxy-container groupings. It is uncertain whether the aforementioned PR was rejected due to its age, complexity, or perceived lack of added-value. It is my hope that this PR is found more suitable for inclusion to the code base.

While the ability to limit proxy-container interaction has general uses (#340), its importance is realized when operating in secured and/or controlled environments, setting limits on a proxy's configuration to only include those containers it needs to know about; especially, when multiple instances are run on the same Docker host.

This feature is especially important for defense contractors for which I design internal infrastructures to compartmentalize information and services for specific purposes. On December 30, 2015, the U.S. Department of Defense announced a change to the Defense Federal Acquistion Regulation Supplement ([DFARS.204-7012](https://www.gpo.gov/fdsys/pkg/CFR-2014-title48-vol3/pdf/CFR-2014-title48-vol3-sec252-204-7012.pdf)), requiring all defense contractors to implement requirements stipulated in [NIST Special Publication 800-171](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf). _Protecting Controlled Unclassified Information in Nonfederal Information Systems and Organizations_ by December 31, 2017.

In short, it all boils down to best practices that ensure information resources are only configured and provide services for their intended purpose and nothing more. A solution over nginx-proxy would be to deploy vanilla Nginx servers with static configurations. However, my preference would be to use nginx-proxy, as we use it in conjunction with letsencrypt-nginx-proxy-companion that communicates with an internal HSM to generate individual short-term site certificates. Furthermore, the dynamic nature of nginx-proxy provides better incident management should services have to be brought down and others spun up quickly.