### PR TITLE
Added custom HSTS support (issue #953)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,13 @@ site after changing this setting, your browser has probably cached the HSTS poli
 redirecting you back to HTTPS.  You will need to clear your browser's HSTS cache or use an incognito 
 window / different browser.
 
+By default, [HTTP Strict Transport Security (HSTS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) 
+is enabled with `max-age=31536000` for HTTPS sites.  You can disable HSTS with the environment variable 
+`HSTS=off` or use a custom HSTS configuration like `HSTS=max-age=31536000; includeSubDomains; preload`.  
+*WARNING*: HSTS will force your users to visit the HTTPS version of your site for the `max-age` time - 
+even if they type in `http://` manually.  The only way to get to an HTTP site after receiving an HSTS 
+response is to clear your browser's HSTS cache.
+
 ### Basic Authentication Support
 
 In order to be able to secure your virtual host, you have to create a file named as its equivalent VIRTUAL_HOST variable on directory

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -158,6 +158,9 @@ upstream {{ $upstream_name }} {
 {{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
 {{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
 
+{{/* Get the HSTS defined by containers w/ the same vhost, falling back to "max-age=31536000" */}}
+{{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) "max-age=31536000" }}
+
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
 
@@ -225,8 +228,8 @@ server {
 	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.crt" $cert }};
 	{{ end }}
 
-	{{ if (ne $https_method "noredirect") }}
-	add_header Strict-Transport-Security "max-age=31536000";
+	{{ if (and (ne $https_method "noredirect") (ne $hsts "off")) }}
+	add_header Strict-Transport-Security "{{ trim $hsts }}";
 	{{ end }}
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}

--- a/test/test_ssl/test_hsts.py
+++ b/test/test_ssl/test_hsts.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def test_web1_HSTS_default(docker_compose, nginxproxy):
+    r = nginxproxy.get("https://web1.nginx-proxy.tld/port", allow_redirects=False)
+    assert "answer from port 81\n" in r.text
+    assert "Strict-Transport-Security" in r.headers
+    assert "max-age=31536000" == r.headers["Strict-Transport-Security"]
+
+def test_web2_HSTS_off(docker_compose, nginxproxy):
+    r = nginxproxy.get("https://web2.nginx-proxy.tld/port", allow_redirects=False)
+    assert "answer from port 81\n" in r.text
+    assert "Strict-Transport-Security" not in r.headers
+
+def test_web3_HSTS_custom(docker_compose, nginxproxy):
+    r = nginxproxy.get("https://web3.nginx-proxy.tld/port", allow_redirects=False)
+    assert "answer from port 81\n" in r.text
+    assert "Strict-Transport-Security" in r.headers
+    assert "max-age=86400; includeSubDomains; preload" == r.headers["Strict-Transport-Security"]

--- a/test/test_ssl/test_hsts.yml
+++ b/test/test_ssl/test_hsts.yml
@@ -1,0 +1,32 @@
+web1:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: "81"
+    VIRTUAL_HOST: "web1.nginx-proxy.tld"
+
+web2:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: "81"
+    VIRTUAL_HOST: "web2.nginx-proxy.tld"
+    HSTS: "off"
+
+web3:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: "81"
+    VIRTUAL_HOST: "web3.nginx-proxy.tld"
+    HSTS: "max-age=86400; includeSubDomains; preload"
+
+sut:
+  image: jwilder/nginx-proxy:test
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ../lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
+    - ./certs:/etc/nginx/certs:ro


### PR DESCRIPTION
This PR adds custom HSTS support as discussed in #953.

It's available from my Docker repo as `kamermans/nginx-proxy:feature_custom_hsts`.

Note that the tests are passing, but there are two other tests failing on my build machine.  At least one of them is due to a change in output in `openssl 1.1.0` on my Ubuntu 17.10 test machine, so I'll probably send a PR for that issue later.