### PR TITLE
Fixed failing SSL tests

### DIFF
--- a/test/test_ssl/test_dhparam.py
+++ b/test/test_ssl/test_dhparam.py
@@ -89,5 +89,5 @@ def test_web5_dhparam_is_used(docker_compose):
 
     host = "%s:443" % sut_container.attrs["NetworkSettings"]["IPAddress"]
     r = subprocess.check_output(
-        "echo '' | openssl s_client -verify 0 -connect %s -cipher 'EDH' | grep 'Server Temp Key'" % host, shell=True)
+        "echo '' | openssl s_client -connect %s -cipher 'EDH' | grep 'Server Temp Key'" % host, shell=True)
     assert "Server Temp Key: DH, 2048 bits\n" == r

--- a/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
+++ b/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
@@ -1,6 +1,5 @@
 import pytest
-from backports.ssl_match_hostname import CertificateError
-
+from requests.exceptions import SSLError
 
 @pytest.mark.parametrize("subdomain,should_redirect_to_https", [
     (1, True),
@@ -23,9 +22,10 @@ def test_https_get_served(docker_compose, nginxproxy, subdomain):
 
 
 def test_web3_https_is_500_and_SSL_validation_fails(docker_compose, nginxproxy):
-    with pytest.raises(CertificateError) as excinfo:
+    with pytest.raises(SSLError) as excinfo:
         nginxproxy.get("https://3.web.nginx-proxy.tld/port")
     assert """hostname '3.web.nginx-proxy.tld' doesn't match 'nginx-proxy.tld'""" in str(excinfo.value)
+
 
     r = nginxproxy.get("https://3.web.nginx-proxy.tld/port", verify=False)
     assert r.status_code == 500

--- a/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
+++ b/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
@@ -1,5 +1,7 @@
 import pytest
+from backports.ssl_match_hostname import CertificateError
 from requests.exceptions import SSLError
+
 
 @pytest.mark.parametrize("subdomain,should_redirect_to_https", [
     (1, True),
@@ -22,10 +24,9 @@ def test_https_get_served(docker_compose, nginxproxy, subdomain):
 
 
 def test_web3_https_is_500_and_SSL_validation_fails(docker_compose, nginxproxy):
-    with pytest.raises(SSLError) as excinfo:
+    with pytest.raises( (CertificateError, SSLError) ) as excinfo:
         nginxproxy.get("https://3.web.nginx-proxy.tld/port")
     assert """hostname '3.web.nginx-proxy.tld' doesn't match 'nginx-proxy.tld'""" in str(excinfo.value)
-
 
     r = nginxproxy.get("https://3.web.nginx-proxy.tld/port", verify=False)
     assert r.status_code == 500


### PR DESCRIPTION
The following tests are failing on my build machine (Ubuntu 17.10):

1. `test_ssl/test_dhparam.py::test_web5_dhparam_is_used` - was failing because the `openssl s_client` was used with `-verify 0` to disable certificate verification.  `-verify 0` has actually been wrong forever, but only recently has `openssl` stopped tolerating it.  Removing the `-verify` statement entirely disables certificate verification properly.

2. `test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py::test_web3_https_is_500_and_SSL_validation_fails` - was failing because `requests` raises a `SSLError(CertificateError)`, but we're expecting the inner error, a `CertificateError`.  I don't know if this is related to my version of Python (`2.7.14`) or `requests` (`2.18.4)`, but on my machine I get an `SSLError`, not a `CertificateError`.

It would be nice to have another pair of eyes on test 2, since python is not my native language.  I wrote test 1 in the first place, so I'm pretty comfortable with that one :)