### PR TITLE
OCSP Stapling was not working

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -222,10 +222,10 @@ server {
 	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
 	{{ end }}
 
-	{{ if (exists (printf "/etc/nginx/certs/%s.chain.crt" $cert)) }}
+	{{ if (exists (printf "/etc/nginx/certs/%s.chain.pem" $cert)) }}
 	ssl_stapling on;
 	ssl_stapling_verify on;
-	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.crt" $cert }};
+	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $cert }};
 	{{ end }}
 
 	{{ if (and (ne $https_method "noredirect") (ne $hsts "off")) }}


### PR DESCRIPTION
The nginx.tmpl was looking for the chain certificate with the file extension of .crt when in fact the chain certificate has a .pem extension. Adjusted the template to ensure SSL stapling was correctly enabled by detecting the correct file.