### PR TITLE
Fixed #1080, can't disable HSTS with noredirect

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -19,7 +19,7 @@
 			server 127.0.0.1 down;
 		{{ end }}
 	{{ end }}
-	
+
 {{ end }}
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
@@ -262,7 +262,7 @@ server {
 	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $cert }};
 	{{ end }}
 
-	{{ if (and (ne $https_method "noredirect") (ne $hsts "off")) }}
+	{{ if (not (or (eq $https_method "noredirect") (eq $hsts "off"))) }}
 	add_header Strict-Transport-Security "{{ trim $hsts }}" always;
 	{{ end }}
 

--- a/test/test_ssl/test_hsts.py
+++ b/test/test_ssl/test_hsts.py
@@ -24,3 +24,10 @@ def test_web3_HSTS_custom(docker_compose, nginxproxy):
     assert "answer from port 81\n" in r.text
     assert "Strict-Transport-Security" in r.headers
     assert "max-age=86400; includeSubDomains; preload" == r.headers["Strict-Transport-Security"]
+
+# Regression test for issue 1080
+# https://github.com/jwilder/nginx-proxy/issues/1080
+def test_web4_HSTS_off_noredirect(docker_compose, nginxproxy):
+    r = nginxproxy.get("https://web4.nginx-proxy.tld/port", allow_redirects=False)
+    assert "answer from port 81\n" in r.text
+    assert "Strict-Transport-Security" not in r.headers

--- a/test/test_ssl/test_hsts.yml
+++ b/test/test_ssl/test_hsts.yml
@@ -24,6 +24,16 @@ web3:
     VIRTUAL_HOST: "web3.nginx-proxy.tld"
     HSTS: "max-age=86400; includeSubDomains; preload"
 
+web4:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: "81"
+    VIRTUAL_HOST: "web4.nginx-proxy.tld"
+    HSTS: "off"
+    HTTPS_METHOD: "noredirect"
+
 sut:
   image: jwilder/nginx-proxy:test
   volumes:


### PR DESCRIPTION
This fixes issue #1080.  It was caused by a typo in the logic which made it impossible to disable HSTS if `HTTPS_METHOD=noredirect`.  Complex logical comparison in this templating language (go's `text/template`) is really confusing!