### PR TITLE
Bugfix: Test reads from out-of-scope var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ env:
   - TEST_TARGET: test-alpine
 
 before_install:
-  - sudo apt-get remove docker docker-engine
+  - sudo apt-get -y remove docker docker-engine docker-ce
+  - sudo rm /etc/apt/sources.list.d/docker.list
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
   - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - sudo apt-get update

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -469,5 +469,5 @@ try:
 except docker.errors.ImageNotFound:
     pytest.exit("The docker image 'jwilder/nginx-proxy:test' is missing")
 
-if docker.__version__ != "2.0.2":
-    pytest.exit("This test suite is meant to work with the python docker module v2.0.2")
+if docker.__version__ != "2.1.0":
+    pytest.exit("This test suite is meant to work with the python docker module v2.1.0")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -257,7 +257,7 @@ def get_nginx_conf_from_container(container):
     strm, stat = container.get_archive('/etc/nginx/conf.d/default.conf')
     with tarfile.open(fileobj=StringIO(strm.read())) as tf:
         conffile = tf.extractfile('default.conf')
-    return conffile.read()
+        return conffile.read()
 
 
 def docker_compose_up(compose_file='docker-compose.yml'):

--- a/test/requirements/python-requirements.txt
+++ b/test/requirements/python-requirements.txt
@@ -1,5 +1,5 @@
 backoff==1.3.2
-docker-compose==1.11.1
-docker==2.0.2
+docker-compose==1.11.2
+docker==2.1.0
 pytest==3.0.5
 requests==2.11.1


### PR DESCRIPTION
I don't know why this only seems to fail in Docker `18.04 RC3`, but I can confirm that it consistently fails in that version and not in older versions.  This actually fixes two bugs:
1. In `docker-compose 1.11.1`, the code pulls some internal code from `pip`, but `pip` removed that code and so `docker-compose` broke.  This was fixed in `docker-compose 1.11.2`, so I've upgraded that, and had to upgrade `docker-py` as well, to meet the minimum requirements.
2. In one of our tests, we were opening a file handle via `with` and reading from it after the `with` was closed, so the variable was out of scope.  Fixed with a single indent.

@jwilder This PR will fix the failing builds in PRs #1123, #1083, #1116, #1120.