### PR TITLE
[FEATURE] Allow multiple ports per virtual host

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,12 @@ If you are using multiple hostnames for a single container (e.g. `VIRTUAL_HOST=e
 If you want most of your virtual hosts to use a default single `location` block configuration and then override on a few specific ones, add those settings to the `/etc/nginx/vhost.d/default_location` file. This file
 will be used on any virtual host which does not have a `/etc/nginx/vhost.d/{VIRTUAL_HOST}_location` file associated with it.
 
+#### Multiple ports per virtual host
+
+A container can expose multiple ports that you want to proxy to different host names. In order to achieve this, you need
+to activate pass `VIRTUAL_HOST_SPECIFIC_PORT` with the value `true` to *nginx-proxy*. Then you can start start any container
+and pass multiple host names and ports `VIRTUAL_HOST=subdomain1.youdomain.com,subdomain2.youdomain.com:5000`
+
 ### Contributing
 
 Before submitting pull requests or issues, please check github to make sure an existing issue or pull request is not already open.

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -160,7 +160,7 @@ upstream {{ $upstream_name }} {
 }
 
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
-{{ $default_server := index (dict $host "" $default_host "default_server") $host }}
+{{ $default_server := index (dict $server_name "" $default_host "default_server") $server_name }}
 
 {{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
 {{ $proto := trim (or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http") }}
@@ -185,7 +185,7 @@ upstream {{ $upstream_name }} {
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
 
 {{/* Get the best matching cert  by name for the vhost. */}}
-{{ $vhostCert := (closest (dir "/etc/nginx/certs") (printf "%s.crt" $host))}}
+{{ $vhostCert := (closest (dir "/etc/nginx/certs") (printf "%s.crt" $server_name))}}
 
 {{/* vhostCert is actually a filename so remove any suffixes since they are added later */}}
 {{ $vhostCert := trimSuffix ".crt" $vhostCert }}
@@ -206,7 +206,7 @@ server {
 	listen [::]:80 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
-	return 301 https://$host$request_uri;
+	return 301 https://$server_name$request_uri;
 }
 {{ end }}
 
@@ -274,8 +274,8 @@ server {
 	add_header Strict-Transport-Security "{{ trim $hsts }}" always;
 	{{ end }}
 
-	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
-	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $server_name)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $server_name }};
 	{{ else if (exists "/etc/nginx/vhost.d/default") }}
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
@@ -292,12 +292,12 @@ server {
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
 
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $server_name)) }}
+		auth_basic	"Restricted {{ $server_name }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $server_name) }};
 		{{ end }}
-		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $server_name)) }}
+		include {{ printf "/etc/nginx/vhost.d/%s_location" $server_name}};
 		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
 		include /etc/nginx/vhost.d/default_location;
 		{{ end }}
@@ -321,8 +321,8 @@ server {
 	include /etc/nginx/network_internal.conf;
 	{{ end }}
 
-	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
-	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $server_name)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $server_name }};
 	{{ else if (exists "/etc/nginx/vhost.d/default") }}
 	include /etc/nginx/vhost.d/default;
 	{{ end }}
@@ -338,12 +338,12 @@ server {
 		{{ else }}
 		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ end }}
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $server_name)) }}
+		auth_basic	"Restricted {{ $server_name }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $server_name) }};
 		{{ end }}
-		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $server_name)) }}
+		include {{ printf "/etc/nginx/vhost.d/%s_location" $server_name }};
 		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
 		include /etc/nginx/vhost.d/default_location;
 		{{ end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -206,7 +206,7 @@ server {
 	listen [::]:80 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
-	return 301 https://$server_name$request_uri;
+	return 301 https://$host$request_uri;
 }
 {{ end }}
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -120,6 +120,8 @@ server {
 {{ $host := trim $host }}
 {{ $is_regexp := hasPrefix "~" $host }}
 {{ $upstream_name := when $is_regexp (sha1 $host) $host }}
+{{ $specific_port := eq (or ($.Env.VIRTUAL_HOST_SPECIFIC_PORT) "") "true" }}
+{{ $server_name := when $specific_port (coalesce (index (split $host ":") 0) $host) $host }}
 
 # {{ $host }}
 upstream {{ $upstream_name }} {
@@ -132,8 +134,13 @@ upstream {{ $upstream_name }} {
 			{{ if (and (ne $containerNetwork.Name "ingress") (or (eq $knownNetwork.Name $containerNetwork.Name) (eq $knownNetwork.Name "host"))) }}
 				## Can be connected with "{{ $containerNetwork.Name }}" network
 
+                {{ if $specific_port }}
+                {{/* If ports per virtual host specified, use that, falling back to standard web port $container.Env.VIRTUAL_PORT and 80 */}}
+                    {{ $port := coalesce (index (split $host ":") 1) $container.Env.VIRTUAL_PORT "80" }}
+                    {{ $address := where $container.Addresses "Port" $port | first }}
+                    {{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{/* If only 1 port exposed, use that */}}
-				{{ if eq $addrLen 1 }}
+				{{ else if eq $addrLen 1 }}
 					{{ $address := index $container.Addresses 0 }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
@@ -192,7 +199,7 @@ upstream {{ $upstream_name }} {
 
 {{ if eq $https_method "redirect" }}
 server {
-	server_name {{ $host }};
+	server_name {{ $server_name }};
 	listen 80 {{ $default_server }};
 	{{ if $enable_ipv6 }}
 	listen [::]:80 {{ $default_server }};
@@ -203,7 +210,7 @@ server {
 {{ end }}
 
 server {
-	server_name {{ $host }};
+	server_name {{ $server_name }};
 	listen 443 ssl http2 {{ $default_server }};
 	{{ if $enable_ipv6 }}
 	listen [::]:443 ssl http2 {{ $default_server }};
@@ -301,7 +308,7 @@ server {
 {{ if or (not $is_https) (eq $https_method "noredirect") }}
 
 server {
-	server_name {{ $host }};
+	server_name {{ $server_name }};
 	listen 80 {{ $default_server }};
 	{{ if $enable_ipv6 }}
 	listen [::]:80 {{ $default_server }};
@@ -344,7 +351,7 @@ server {
 
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
-	server_name {{ $host }};
+	server_name {{ $server_name }};
 	listen 443 ssl http2 {{ $default_server }};
 	{{ if $enable_ipv6 }}
 	listen [::]:443 ssl http2 {{ $default_server }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -119,9 +119,9 @@ server {
 
 {{ $host := trim $host }}
 {{ $is_regexp := hasPrefix "~" $host }}
-{{ $upstream_name := when $is_regexp (sha1 $host) $host }}
-{{ $specific_port := eq (or ($.Env.VIRTUAL_HOST_SPECIFIC_PORT) "") "true" }}
-{{ $server_name := when $specific_port (coalesce (index (split $host ":") 0) $host) $host }}
+{{ $is_specific_port := eq (or ($.Env.VIRTUAL_HOST_SPECIFIC_PORT) "") "true" }}
+{{ $upstream_name := when (or $is_regexp $is_specific_port) (sha1 $host) $host }}
+{{ $server_name := when $is_specific_port (index (split $host ":") 0) $host }}
 
 # {{ $host }}
 upstream {{ $upstream_name }} {
@@ -134,9 +134,10 @@ upstream {{ $upstream_name }} {
 			{{ if (and (ne $containerNetwork.Name "ingress") (or (eq $knownNetwork.Name $containerNetwork.Name) (eq $knownNetwork.Name "host"))) }}
 				## Can be connected with "{{ $containerNetwork.Name }}" network
 
-                {{ if $specific_port }}
-                {{/* If ports per virtual host specified, use that, falling back to standard web port $container.Env.VIRTUAL_PORT and 80 */}}
-                    {{ $port := coalesce (index (split $host ":") 1) $container.Env.VIRTUAL_PORT "80" }}
+                {{ $split_host_port := split $host ":" }}
+                {{ if (and $is_specific_port (eq (len $split_host_port) 2)) }}
+                {{/* If ports per virtual host specified, use that */}}
+                    {{ $port := index $split_host_port 1 }}
                     {{ $address := where $container.Addresses "Port" $port | first }}
                     {{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{/* If only 1 port exposed, use that */}}

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 # disable the creation of the `.cache` folders
-addopts = -p no:cacheprovider --ignore=requirements --ignore=certs -r s -v
+addopts = -k "specified_mixed" -p no:cacheprovider --ignore=requirements --ignore=certs -r s -v

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 # disable the creation of the `.cache` folders
-addopts = -k "specified_mixed" -p no:cacheprovider --ignore=requirements --ignore=certs -r s -v
+addopts = -p no:cacheprovider --ignore=requirements --ignore=certs -r s -v

--- a/test/test_specific-ports/test_specified_all.py
+++ b/test/test_specific-ports/test_specified_all.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def test_unknown_virtual_host_is_503(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://unknown.nginx-proxy.tld/port")
+    assert r.status_code == 503
+
+def test_webA_is_forwarded(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://webA.nginx-proxy.tld/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 5000\n"
+
+def test_webB_is_forwarded(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://webB.nginx-proxy.tld/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 5001\n"

--- a/test/test_specific-ports/test_specified_all.yml
+++ b/test/test_specific-ports/test_specified_all.yml
@@ -1,15 +1,17 @@
 web:
   image: web
   expose:
-    - "81"
+    - "5000"
+    - "5001"
   environment:
-    WEB_PORTS: 81
+    WEB_PORTS: "5000 5001"
     VIRTUAL_HOST: webA.nginx-proxy.tld:5000,webB.nginx-proxy.tld:5001
-    VIRTUAL_HOST_SPECIFIC_PORT: "true"
 
 
 sut:
   image: jwilder/nginx-proxy:test
   volumes:
     - /var/run/docker.sock:/tmp/docker.sock:ro
-    - ./lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
+    - ../lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
+  environment:
+    VIRTUAL_HOST_SPECIFIC_PORT: "true"

--- a/test/test_specific-ports/test_specified_all.yml
+++ b/test/test_specific-ports/test_specified_all.yml
@@ -1,0 +1,15 @@
+web:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: 81
+    VIRTUAL_HOST: webA.nginx-proxy.tld:5000,webB.nginx-proxy.tld:5001
+    VIRTUAL_HOST_SPECIFIC_PORT: true
+
+
+sut:
+  image: jwilder/nginx-proxy:test
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ./lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro

--- a/test/test_specific-ports/test_specified_all.yml
+++ b/test/test_specific-ports/test_specified_all.yml
@@ -5,7 +5,7 @@ web:
   environment:
     WEB_PORTS: 81
     VIRTUAL_HOST: webA.nginx-proxy.tld:5000,webB.nginx-proxy.tld:5001
-    VIRTUAL_HOST_SPECIFIC_PORT: true
+    VIRTUAL_HOST_SPECIFIC_PORT: "true"
 
 
 sut:

--- a/test/test_specific-ports/test_specified_mixed.py
+++ b/test/test_specific-ports/test_specified_mixed.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def test_unknown_virtual_host_is_503(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://unknown.nginx-proxy.tld/port")
+    assert r.status_code == 503
+
+def test_webA_is_forwarded(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://webA.nginx-proxy.tld/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 80\n"
+
+def test_webB_is_forwarded(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://webB.nginx-proxy.tld/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 5001\n"

--- a/test/test_specific-ports/test_specified_mixed.yml
+++ b/test/test_specific-ports/test_specified_mixed.yml
@@ -2,9 +2,10 @@ web:
   image: web
   expose:
     - "80"
+    - "5001"
   environment:
-    WEB_PORTS: 80
-    VIRTUAL_HOST: webA.nginx-proxy.tld,webB.nginx-proxy.tld
+    WEB_PORTS: "80 5001"
+    VIRTUAL_HOST: webA.nginx-proxy.tld,webB.nginx-proxy.tld:5001
 
 
 sut:

--- a/test/test_specific-ports/test_specified_none.py
+++ b/test/test_specific-ports/test_specified_none.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def test_unknown_virtual_host_is_503(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://unknown.nginx-proxy.tld/port")
+    assert r.status_code == 503
+
+def test_webA_is_forwarded(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://webA.nginx-proxy.tld/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 80\n"
+
+def test_webB_is_forwarded(docker_compose, nginxproxy):
+    r = nginxproxy.get("http://webB.nginx-proxy.tld/port")
+    assert r.status_code == 200
+    assert r.text == "answer from port 80\n"

--- a/test/test_specific-ports/test_specified_none.yml
+++ b/test/test_specific-ports/test_specified_none.yml
@@ -1,0 +1,15 @@
+web:
+  image: web
+  expose:
+    - "81"
+  environment:
+    WEB_PORTS: 81
+    VIRTUAL_HOST: webA.nginx-proxy.tld,webB.nginx-proxy.tld
+    VIRTUAL_HOST_SPECIFIC_PORT: true
+
+
+sut:
+  image: jwilder/nginx-proxy:test
+  volumes:
+    - /var/run/docker.sock:/tmp/docker.sock:ro
+    - ./lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro

--- a/test/test_specific-ports/test_specified_none.yml
+++ b/test/test_specific-ports/test_specified_none.yml
@@ -5,7 +5,7 @@ web:
   environment:
     WEB_PORTS: 81
     VIRTUAL_HOST: webA.nginx-proxy.tld,webB.nginx-proxy.tld
-    VIRTUAL_HOST_SPECIFIC_PORT: true
+    VIRTUAL_HOST_SPECIFIC_PORT: "true"
 
 
 sut:


### PR DESCRIPTION
This feature allows to have different ports for multiple virtual hosts. By passing the environment variable `VIRTUAL_HOST_SPECIFIC_PORT=true` to *nginx-proxy* container, you can then specify ports per proxied container per virtual host `VIRTUAL_HOST=host1.tld:80,host2.tld:81,host1.tld:5005`. It uses an alternative approach then others have suggested. This is backward compatible because you must first enable the feature in the *nginx-proxy*.

It contains tests for the following cases:
- all proxied hosts specify a port
- no proxied host specifies a port
- some proxied hosts specifiy a port

Fixes the following issues:
- #59 
- #510 
- #560
- #1042
- #1066 

Finally, documentation for this feature has been added to the README.