### PR TITLE
Feature: Listen Ports for HTTP/HTTPS

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -124,12 +124,6 @@ server {
 # {{ $host }}
 upstream {{ $upstream_name }} {
 
-{{/* Get the VIRTUAL_LISTEN_HTTP defined by containers w/ the same vhost, falling back to "80" */}}
-{{ $listen_http := trim (or (first (groupByKeys $containers "Env.VIRTUAL_LISTEN_HTTP")) "80") }}
-
-{{/* Get the VIRTUAL_LISTEN_HTTPS defined by containers w/ the same vhost, falling back to "443" */}}
-{{ $listen_https := trim (or (first (groupByKeys $containers "Env.VIRTUAL_LISTEN_HTTPS")) "443") }}
-
 {{ range $container := $containers }}
 	{{ $addrLen := len $container.Addresses }}
 
@@ -156,6 +150,12 @@ upstream {{ $upstream_name }} {
 	{{ end }}
 {{ end }}
 }
+
+{{/* Get the VIRTUAL_LISTEN_HTTP defined by containers w/ the same vhost, falling back to "80" */}}
+{{ $listen_http := (groupByKeys $containers "Env.VIRTUAL_LISTEN_HTTP")  }}
+
+{{/* Get the VIRTUAL_LISTEN_HTTPS defined by containers w/ the same vhost, falling back to "443" */}}
+{{ $listen_https := (groupByKeys $containers "Env.VIRTUAL_LISTEN_HTTPS") }}
 
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
@@ -199,9 +199,17 @@ upstream {{ $upstream_name }} {
 {{ if eq $https_method "redirect" }}
 server {
 	server_name {{ $host }};
-	listen {{ $listen_http }} {{ $default_server }};
+	{{ if not (intersect $listen_http (split "80" ",")) }}
+	listen 80 {{ $default_server }};
+	{{ end }}
+	{{ range $i, $lport := $listen_http }}
+	listen {{ $lport }} {{ $default_server }};
+	{{ end }}
 	{{ if $enable_ipv6 }}
-	listen [::]:{{ $listen_http }} {{ $default_server }};
+	{{ range $i, $lport := $listen_http }}
+	listen [::]:{{ $lport }} {{ $default_server }};
+	{{ end }}
+
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 	return 301 https://$host$request_uri;
@@ -210,9 +218,20 @@ server {
 
 server {
 	server_name {{ $host }};
-	listen {{ $listen_https }} ssl http2 {{ $default_server }};
+	{{ if not (intersect $listen_https (split "443" ",")) }}
+	listen 443 ssl http2 {{ $default_server }};
+	{{ end }}
+
+	{{ range $i, $lport := $listen_https }}
+	listen {{ $lport }} ssl http2 {{ $default_server }};
+	{{ end }}
 	{{ if $enable_ipv6 }}
-	listen [::]:{{ $listen_https }} ssl http2 {{ $default_server }};
+	{{ if not (intersect $listen_https (split "443" ",")) }}
+	listen [::]:443 ssl http2 {{ $default_server }};
+	{{ end }}
+	{{ range $i, $lport := $listen_https }}
+	listen [::]:{{ $lport }} ssl http2 {{ $default_server }};
+	{{ end }}
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 
@@ -308,9 +327,20 @@ server {
 
 server {
 	server_name {{ $host }};
-	listen {{ $listen_http }} {{ $default_server }};
+	{{ if not (intersect $listen_http (split "80" ",")) }}
+	listen 80 {{ $default_server }};
+	{{ end }}
+	
+	{{ range $i, $lport := $listen_http }}
+	listen {{ $lport }} {{ $default_server }};
+	{{ end }}
 	{{ if $enable_ipv6 }}
-	listen [::]:{{ $listen_http }} {{ $default_server }};
+	{{ if not (intersect $listen_http (split "80" ",")) }}
+	listen [::]:80 {{ $default_server }};
+	{{ end }}
+	{{ range $i, $lport := $listen_http }}
+	listen [::]:{{ $lport }} {{ $default_server }};
+	{{ end }}
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 
@@ -351,9 +381,19 @@ server {
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name {{ $host }};
-	listen {{ $listen_https }} ssl http2 {{ $default_server }};
+	{{ if not (intersect $listen_https (split "443" ",")) }}
+	listen 443 {{ $default_server }};
+	{{ end }}
+	{{ range $i, $lport := $listen_https }}
+	listen {{ $lport }} {{ $default_server }};
+	{{ end }}
 	{{ if $enable_ipv6 }}
-	listen [::]:{{ $listen_https }} ssl http2 {{ $default_server }};
+	{{ if not (intersect $listen_https (split "443" ",")) }}
+	listen [::]:443 {{ $default_server }};
+	{{ end }}
+	{{ range $i, $lport := $listen_https }}
+	listen [::]:{{ $lport }} {{ $default_server }};
+	{{ end }}
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 	return 500;

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -124,6 +124,12 @@ server {
 # {{ $host }}
 upstream {{ $upstream_name }} {
 
+{{/* Get the VIRTUAL_LISTEN_HTTP defined by containers w/ the same vhost, falling back to "80" */}}
+{{ $listen_http := trim (or (first (groupByKeys $containers "Env.VIRTUAL_LISTEN_HTTP")) "80") }}
+
+{{/* Get the VIRTUAL_LISTEN_HTTPS defined by containers w/ the same vhost, falling back to "443" */}}
+{{ $listen_https := trim (or (first (groupByKeys $containers "Env.VIRTUAL_LISTEN_HTTPS")) "443") }}
+
 {{ range $container := $containers }}
 	{{ $addrLen := len $container.Addresses }}
 
@@ -193,9 +199,9 @@ upstream {{ $upstream_name }} {
 {{ if eq $https_method "redirect" }}
 server {
 	server_name {{ $host }};
-	listen 80 {{ $default_server }};
+	listen {{ $listen_http }} {{ $default_server }};
 	{{ if $enable_ipv6 }}
-	listen [::]:80 {{ $default_server }};
+	listen [::]:{{ $listen_http }} {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 	return 301 https://$host$request_uri;
@@ -204,9 +210,9 @@ server {
 
 server {
 	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
+	listen {{ $listen_https }} ssl http2 {{ $default_server }};
 	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl http2 {{ $default_server }};
+	listen [::]:{{ $listen_https }} ssl http2 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 
@@ -302,9 +308,9 @@ server {
 
 server {
 	server_name {{ $host }};
-	listen 80 {{ $default_server }};
+	listen {{ $listen_http }} {{ $default_server }};
 	{{ if $enable_ipv6 }}
-	listen [::]:80 {{ $default_server }};
+	listen [::]:{{ $listen_http }} {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 
@@ -345,9 +351,9 @@ server {
 {{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
+	listen {{ $listen_https }} ssl http2 {{ $default_server }};
 	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl http2 {{ $default_server }};
+	listen [::]:{{ $listen_https }} ssl http2 {{ $default_server }};
 	{{ end }}
 	access_log /var/log/nginx/access.log vhost;
 	return 500;


### PR DESCRIPTION
Currently ports 80 and 443 are hard coded for HTTP and HTTPS respectively.
Many applications run on non-standard ports.  This change allows a per VHost change of the defaults by including the following Env values on the VHOST container:
VIRTUAL_LISTEN_HTTP
VIRTUAL_LISTEN_HTTPS
