### PR TITLE
Fix empty dhparam.pem

### DIFF
--- a/generate-dhparam.sh
+++ b/generate-dhparam.sh
@@ -37,7 +37,8 @@ touch $GEN_LOCKFILE
 # Generate a new dhparam in the background in a low priority and reload nginx when finished (grep removes the progress indicator).
 (
     (
-        nice -n +5 openssl dhparam -out $DHPARAM_FILE $DHPARAM_BITS 2>&1 \
+        nice -n +5 openssl dhparam -out $DHPARAM_FILE.tmp $DHPARAM_BITS 2>&1 \
+        && mv $DHPARAM_FILE.tmp $DHPARAM_FILE \
         && echo "dhparam generation complete, reloading nginx" \
         && nginx -s reload
     ) | grep -vE '^[\.+]+'


### PR DESCRIPTION
When launch the container, the default dhparam.pem is cleared to 0 by shell redirection while creating a new dhparam.pem.

```
# docker exec -it 0841481db300 bash
root@0841481db300:/app# cd /etc/nginx/dhparam/
root@0841481db300:/etc/nginx/dhparam# ls -lha
total 0
drwxr-xr-x 1 root root 25 Dec 16 13:40 .
drwxr-xr-x 1 root root 35 Dec 16 12:18 ..
-rw-r--r-- 1 root root  0 Dec 16 13:40 dhparam.pem
```

So, nginx sometimes fails to initialize.

```
# docker logs 0841481db300
WARNING: /etc/nginx/dhparam/dhparam.pem was not found. A pre-generated dhparam.pem will be used for now while a new one
is being generated in the background.  Once the new dhparam.pem is in place, nginx will be reloaded.
forego     | starting dockergen.1 on port 5000
forego     | starting nginx.1 on port 5100
dockergen.1 | 2018/12/16 13:40:02 Generated '/etc/nginx/conf.d/default.conf' from 7 containers
dockergen.1 | 2018/12/16 13:40:02 Running 'nginx -s reload'
dockergen.1 | 2018/12/16 13:40:02 Error running notify command: nginx -s reload, exit status 1
dockergen.1 | 2018/12/16 13:40:02 Watching docker events
dockergen.1 | 2018/12/16 13:40:03 Contents of /etc/nginx/conf.d/default.conf did not change. Skipping notification 'nginx -s reload'
```