### PR TITLE
Fixed tests that are now failing due to the dhparam clearing command …

### DIFF
--- a/test/test_ssl/wildcard_cert_and_nohttps/docker-compose.yml
+++ b/test/test_ssl/wildcard_cert_and_nohttps/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       - ./certs:/etc/nginx/certs:ro
+      - ../../lib/ssl/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
 
   web1:
     image: web

--- a/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
+++ b/test/test_ssl/wildcard_cert_and_nohttps/test_wildcard_cert_nohttps.py
@@ -11,6 +11,7 @@ from requests.exceptions import SSLError
 def test_http_redirects_to_https(docker_compose, nginxproxy, subdomain, should_redirect_to_https):
     r = nginxproxy.get("http://%s.web.nginx-proxy.tld/port" % subdomain)
     if should_redirect_to_https:
+        assert len(r.history) > 0
         assert r.history[0].is_redirect
         assert r.history[0].headers.get("Location") == "https://%s.web.nginx-proxy.tld/port" % subdomain
     assert "answer from port 8%s\n" % subdomain == r.text


### PR DESCRIPTION
Fixed tests that are now failing due to the dhparam clearing command beating nginx startup.  This is fixed permanently in #1213, but this PR fixes the test so as not to rely on the dhparam autogen, which is tested elsewhere.

To reiterate, we really need to merge #1213 because without it, some users will also face this problem (nginx starting or failing to reload because the `dhparam` file generation has started, but not finished yet, and so the file is empty, causing nginx start/reload to fail).