### PR TITLE
Use labels instead of env variables

### DIFF
--- a/docker-compose-separate-containers.yml
+++ b/docker-compose-separate-containers.yml
@@ -19,5 +19,5 @@ services:
 
   whoami:
     image: jwilder/whoami
-    environment:
-      - VIRTUAL_HOST=whoami.local
+    labels:
+      '@proxy/virtualHost': whoami.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2'
+
 services:
   nginx-proxy:
     image: jwilder/nginx-proxy
-    container_name: nginx-proxy
     ports:
       - "80:80"
     volumes:
@@ -10,5 +10,5 @@ services:
 
   whoami:
     image: jwilder/whoami
-    environment:
-      - VIRTUAL_HOST=whoami.local
+    labels:
+      '@proxy/virtualHost': whoami.local

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -115,7 +115,7 @@ server {
 }
 {{ end }}
 
-{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+{{ range $host, $containers := groupByMulti $ "Labels.@proxy/virtualHost" "," }}
 
 {{ $host := trim $host }}
 {{ $is_regexp := hasPrefix "~" $host }}
@@ -136,9 +136,9 @@ upstream {{ $upstream_name }} {
 				{{ if eq $addrLen 1 }}
 					{{ $address := index $container.Addresses 0 }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
-				{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
+				{{/* If more than one port exposed, use the one matching @proxy/virtualPort label, falling back to standard web port 80 */}}
 				{{ else }}
-					{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
+					{{ $port := coalesce $container.Labels "@proxy/virtualPort" "80" }}
 					{{ $address := where $container.Addresses "Port" $port | first }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{ end }}
@@ -154,27 +154,27 @@ upstream {{ $upstream_name }} {
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
 {{ $default_server := index (dict $host "" $default_host "default_server") $host }}
 
-{{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
-{{ $proto := trim (or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http") }}
+{{/* Get the @proxy/virtualProtocol defined by containers w/ the same vhost, falling back to "http" */}}
+{{ $proto := trim (or (first (groupByKeys $containers "Labels.@proxy/virtualProtocol")) "http") }}
 
 {{/* Get the NETWORK_ACCESS defined by containers w/ the same vhost, falling back to "external" */}}
-{{ $network_tag := or (first (groupByKeys $containers "Env.NETWORK_ACCESS")) "external" }}
+{{ $network_tag := or (first (groupByKeys $containers "Labels.@proxy/networkAccess")) "external" }}
 
-{{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
-{{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
+{{/* Get the @proxy/httpsMethod defined by containers w/ the same vhost, falling back to "redirect" */}}
+{{ $https_method := or (first (groupByKeys $containers "Labels.@proxy/httpsMethod")) "redirect" }}
 
 {{/* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to "Mozilla-Intermediate" */}}
-{{ $ssl_policy := or (first (groupByKeys $containers "Env.SSL_POLICY")) "Mozilla-Intermediate" }}
+{{ $ssl_policy := or (first (groupByKeys $containers "Labels.@proxy/sslPolicy")) "Mozilla-Intermediate" }}
 
 {{/* Get the HSTS defined by containers w/ the same vhost, falling back to "max-age=31536000" */}}
-{{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) "max-age=31536000" }}
+{{ $hsts := or (first (groupByKeys $containers "Labels.@proxy/HSTS")) "max-age=31536000" }}
 
-{{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
-{{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
+{{/* Get the @proxy/virtualRoot By containers w/ use fastcgi root */}}
+{{ $vhost_root := or (first (groupByKeys $containers "Labels.@proxy/virtualRoot")) "/var/www/public" }}
 
 
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
-{{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
+{{ $certName := (first (groupByKeys $containers "Labels.@proxy/certificateName")) }}
 
 {{/* Get the best matching cert  by name for the vhost. */}}
 {{ $vhostCert := (closest (dir "/etc/nginx/certs") (printf "%s.crt" $host))}}

--- a/test/stress_tests/test_deleted_cert/docker-compose.yml
+++ b/test/stress_tests/test_deleted_cert/docker-compose.yml
@@ -4,7 +4,8 @@ web:
   - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: web.nginx-proxy
+  labels:
+    '@proxy/virtualHost': web.nginx-proxy
 
 
 reverseproxy:

--- a/test/stress_tests/test_unreachable_network/README.md
+++ b/test/stress_tests/test_unreachable_network/README.md
@@ -1,6 +1,6 @@
 # nginx-proxy template is not considered when a container is not reachable
 
-Having a container with the `VIRTUAL_HOST` environment variable set but on a network not reachable from the nginx-proxy container will result in nginx-proxy serving the default nginx welcome page for all requests.
+Having a container with the `@proxy/virtualHost` label set but on a network not reachable from the nginx-proxy container will result in nginx-proxy serving the default nginx welcome page for all requests.
 
 Furthermore, if the nginx-proxy in such state is restarted, the nginx process will crash and the container stops.
 

--- a/test/stress_tests/test_unreachable_network/docker-compose.yml
+++ b/test/stress_tests/test_unreachable_network/docker-compose.yml
@@ -21,7 +21,8 @@ services:
       - 81
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: webA.nginx-proxy
+    labels:
+      '@proxy/virtualHost': webA.nginx-proxy
 
   webB:
     networks:
@@ -31,5 +32,6 @@ services:
       - 82
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: webB.nginx-proxy
+    labels:
+      '@proxy/virtualHost': webB.nginx-proxy
 

--- a/test/test_DOCKER_HOST_unix_socket.yml
+++ b/test/test_DOCKER_HOST_unix_socket.yml
@@ -4,7 +4,8 @@ web1:
     - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: web1.nginx-proxy.tld
+  labels:
+    '@proxy/virtualHost': web1.nginx-proxy.tld
 
 web2:
   image: web
@@ -12,7 +13,8 @@ web2:
     - "82"
   environment:
     WEB_PORTS: 82
-    VIRTUAL_HOST: web2.nginx-proxy.tld
+  labels:
+    '@proxy/virtualHost': web2.nginx-proxy.tld
 
 
 sut:

--- a/test/test_composev2.yml
+++ b/test/test_composev2.yml
@@ -12,4 +12,5 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web.nginx-proxy.local

--- a/test/test_custom/test_defaults-location.yml
+++ b/test/test_custom/test_defaults-location.yml
@@ -12,7 +12,8 @@ web1:
     - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: web1.nginx-proxy.local
+  labels:
+    '@proxy/virtualHost': web1.nginx-proxy.local
 
 web2:
   image: web
@@ -20,7 +21,8 @@ web2:
     - "82"
   environment:
     WEB_PORTS: 82
-    VIRTUAL_HOST: web2.nginx-proxy.local
+  labels:
+    '@proxy/virtualHost': web2.nginx-proxy.local
 
 web3:
   image: web
@@ -28,4 +30,5 @@ web3:
     - "83"
   environment:
     WEB_PORTS: 83
-    VIRTUAL_HOST: web3.nginx-proxy.local
+  labels:
+    '@proxy/virtualHost': web3.nginx-proxy.local

--- a/test/test_custom/test_defaults.yml
+++ b/test/test_custom/test_defaults.yml
@@ -13,7 +13,8 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web1.nginx-proxy.local
 
   web2:
     image: web
@@ -21,4 +22,5 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web2.nginx-proxy.local

--- a/test/test_custom/test_location-per-vhost.yml
+++ b/test/test_custom/test_location-per-vhost.yml
@@ -13,7 +13,8 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web1.nginx-proxy.local
 
   web2:
     image: web
@@ -21,4 +22,5 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web2.nginx-proxy.local

--- a/test/test_custom/test_per-vhost.yml
+++ b/test/test_custom/test_per-vhost.yml
@@ -13,7 +13,8 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web1.nginx-proxy.local
 
   web2:
     image: web
@@ -21,4 +22,5 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web2.nginx-proxy.local

--- a/test/test_custom/test_proxy-wide.yml
+++ b/test/test_custom/test_proxy-wide.yml
@@ -13,7 +13,8 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web1.nginx-proxy.local
 
   web2:
     image: web
@@ -21,4 +22,5 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web2.nginx-proxy.local

--- a/test/test_default-host.yml
+++ b/test/test_default-host.yml
@@ -1,11 +1,12 @@
-# GIVEN a webserver with VIRTUAL_HOST set to web1.tld
+# GIVEN a webserver with @proxy/virtualHost set to web1.tld
 web1:
   image: web
   expose:
     - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: web1.tld
+  labels:
+    '@proxy/virtualHost': web1.tld
 
 
 # WHEN nginx-proxy runs with DEFAULT_HOST set to web1.tld

--- a/test/test_dockergen/test_dockergen_v2.yml
+++ b/test/test_dockergen/test_dockergen_v2.yml
@@ -24,4 +24,5 @@ services:
       - "80"
     environment:
       WEB_PORTS: 80
-      VIRTUAL_HOST: whoami.nginx.container.docker
+    labels:
+      '@proxy/virtualHost': whoami.nginx.container.docker

--- a/test/test_dockergen/test_dockergen_v3.yml
+++ b/test/test_dockergen/test_dockergen_v3.yml
@@ -22,7 +22,8 @@ services:
       - "80"
     environment:
       WEB_PORTS: 80
-      VIRTUAL_HOST: whoami.nginx.container.docker
+    labels:
+      '@proxy/virtualHost': whoami.nginx.container.docker
 
 volumes:
   nginx_conf: {}

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -10,7 +10,7 @@ from docker.errors import NotFound
 @pytest.yield_fixture()
 def web1(docker_compose):
     """
-    pytest fixture creating a web container with `VIRTUAL_HOST=web1.nginx-proxy` listening on port 81.
+    pytest fixture creating a web container with `@proxy/virtualHost=web1.nginx-proxy` listening on port 81.
     """
     container = docker_compose.containers.run(
         name="web1",
@@ -18,7 +18,9 @@ def web1(docker_compose):
         detach=True,
         environment={
             "WEB_PORTS": "81",
-            "VIRTUAL_HOST": "web1.nginx-proxy"
+        },
+        labels={
+            "@proxy/virtualHost": "web1.nginx-proxy"
         },
         ports={"81/tcp": None}
     )

--- a/test/test_headers/test_http.yml
+++ b/test/test_headers/test_http.yml
@@ -4,7 +4,8 @@ web:
     - "80"
   environment:
     WEB_PORTS: 80
-    VIRTUAL_HOST: web.nginx-proxy.tld
+  labels:
+    '@proxy/virtualHost': web.nginx-proxy.tld
 
 
 sut:

--- a/test/test_headers/test_https.yml
+++ b/test/test_headers/test_https.yml
@@ -4,7 +4,8 @@ web:
     - "80"
   environment:
     WEB_PORTS: 80
-    VIRTUAL_HOST: web.nginx-proxy.tld
+  labels:
+    '@proxy/virtualHost': web.nginx-proxy.tld
 
 
 sut:

--- a/test/test_ipv6.yml
+++ b/test/test_ipv6.yml
@@ -4,7 +4,8 @@ web1:
     - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: web1.nginx-proxy.tld
+  labels:
+    '@proxy/virtualHost': web1.nginx-proxy.tld
 
 web2:
   image: web
@@ -12,7 +13,8 @@ web2:
     - "82"
   environment:
     WEB_PORTS: 82
-    VIRTUAL_HOST: web2.nginx-proxy.tld
+  labels:
+    '@proxy/virtualHost': web2.nginx-proxy.tld
 
 
 sut:

--- a/test/test_multiple-hosts.yml
+++ b/test/test_multiple-hosts.yml
@@ -4,7 +4,8 @@ web:
     - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: webA.nginx-proxy.tld,webB.nginx-proxy.tld
+  labels:
+    '@proxy/virtualHost': webA.nginx-proxy.tld,webB.nginx-proxy.tld
 
 
 sut:

--- a/test/test_multiple-networks.yml
+++ b/test/test_multiple-networks.yml
@@ -20,7 +20,8 @@ services:
       - "81"
     environment:
       WEB_PORTS: 81
-      VIRTUAL_HOST: web1.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web1.nginx-proxy.local
     networks:
       - net1
 
@@ -30,6 +31,7 @@ services:
       - "82"
     environment:
       WEB_PORTS: 82
-      VIRTUAL_HOST: web2.nginx-proxy.local
+    labels:
+      '@proxy/virtualHost': web2.nginx-proxy.local
     networks:
       - net2

--- a/test/test_multiple-ports/test_VIRTUAL_PORT.yml
+++ b/test/test_multiple-ports/test_VIRTUAL_PORT.yml
@@ -5,8 +5,9 @@ web:
     - "90"
   environment:
     WEB_PORTS: "80 90"
-    VIRTUAL_HOST: "web.nginx-proxy.tld"
-    VIRTUAL_PORT: 90
+  labels:
+    '@proxy/virtualHost': "web.nginx-proxy.tld"
+    '@proxy/virtualPort': "90"
 
 sut:
   image: jwilder/nginx-proxy:test

--- a/test/test_multiple-ports/test_default-80.yml
+++ b/test/test_multiple-ports/test_default-80.yml
@@ -5,7 +5,8 @@ web:
     - "81"
   environment:
     WEB_PORTS: "80 81"
-    VIRTUAL_HOST: "web.nginx-proxy.tld"
+  labels:
+    '@proxy/virtualHost': "web.nginx-proxy.tld"
 
 sut:
   image: jwilder/nginx-proxy:test

--- a/test/test_multiple-ports/test_single-port-not-80.yml
+++ b/test/test_multiple-ports/test_single-port-not-80.yml
@@ -4,7 +4,8 @@ web:
     - "81"
   environment:
     WEB_PORTS: "81"
-    VIRTUAL_HOST: "web.nginx-proxy.tld"
+  labels:
+    '@proxy/virtualHost': "web.nginx-proxy.tld"
 
 
 sut:

--- a/test/test_nominal.yml
+++ b/test/test_nominal.yml
@@ -4,7 +4,8 @@ web1:
     - "81"
   environment:
     WEB_PORTS: 81
-    VIRTUAL_HOST: web1.nginx-proxy.tld
+  labels:
+    '@proxy/virtualHost': web1.nginx-proxy.tld
 
 web2:
   image: web
@@ -12,7 +13,8 @@ web2:
     - "82"
   environment:
     WEB_PORTS: 82
-    VIRTUAL_HOST: web2.nginx-proxy.tld
+  labels:
+    '@proxy/virtualHost': web2.nginx-proxy.tld
 
 
 sut:

--- a/test/test_ssl/test_dhparam.yml
+++ b/test/test_ssl/test_dhparam.yml
@@ -4,7 +4,8 @@ web5:
     - "85"
   environment:
     WEB_PORTS: "85"
-    VIRTUAL_HOST: "web5.nginx-proxy.tld"
+  labels:
+    '@proxy/virtualHost': "web5.nginx-proxy.tld"
 
 
 sut:

--- a/test/test_ssl/test_hsts.yml
+++ b/test/test_ssl/test_hsts.yml
@@ -4,7 +4,8 @@ web1:
     - "81"
   environment:
     WEB_PORTS: "81"
-    VIRTUAL_HOST: "web1.nginx-proxy.tld"
+  labels:
+    '@proxy/virtualHost': "web1.nginx-proxy.tld"
 
 web2:
   image: web
@@ -12,8 +13,9 @@ web2:
     - "81"
   environment:
     WEB_PORTS: "81"
-    VIRTUAL_HOST: "web2.nginx-proxy.tld"
-    HSTS: "off"
+  labels:
+    '@proxy/virtualHost': "web2.nginx-proxy.tld"
+    '@proxy/HSTS': "off"
 
 web3:
   image: web
@@ -21,8 +23,9 @@ web3:
     - "81"
   environment:
     WEB_PORTS: "81"
-    VIRTUAL_HOST: "web3.nginx-proxy.tld"
-    HSTS: "max-age=86400; includeSubDomains; preload"
+  labels:
+    '@proxy/virtualHost': "web3.nginx-proxy.tld"
+    '@proxy/HSTS': "max-age=86400; includeSubDomains; preload"
 
 web4:
   image: web
@@ -30,9 +33,10 @@ web4:
     - "81"
   environment:
     WEB_PORTS: "81"
-    VIRTUAL_HOST: "web4.nginx-proxy.tld"
-    HSTS: "off"
-    HTTPS_METHOD: "noredirect"
+  labels:
+    '@proxy/virtualHost': "web4.nginx-proxy.tld"
+    '@proxy/HSTS': "off"
+    '@proxy/httpsMethod': "noredirect"
 
 sut:
   image: jwilder/nginx-proxy:test

--- a/test/test_ssl/test_nohttp.yml
+++ b/test/test_ssl/test_nohttp.yml
@@ -4,8 +4,9 @@ web2:
     - "82"
   environment:
     WEB_PORTS: "82"
-    VIRTUAL_HOST: "web2.nginx-proxy.tld"
-    HTTPS_METHOD: nohttp
+  labels:
+    '@proxy/virtualHost': "web2.nginx-proxy.tld"
+    '@proxy/httpsMethod': nohttp
 
 
 sut:

--- a/test/test_ssl/test_nohttps.yml
+++ b/test/test_ssl/test_nohttps.yml
@@ -4,8 +4,9 @@ web:
     - "83"
   environment:
     WEB_PORTS: "83"
-    VIRTUAL_HOST: "web.nginx-proxy.tld"
-    HTTPS_METHOD: nohttps
+  labels:
+    '@proxy/virtualHost': "web.nginx-proxy.tld"
+    '@proxy/httpsMethod': nohttps
 
 
 sut:

--- a/test/test_ssl/test_noredirect.yml
+++ b/test/test_ssl/test_noredirect.yml
@@ -4,8 +4,9 @@ web3:
     - "83"
   environment:
     WEB_PORTS: "83"
-    VIRTUAL_HOST: "web3.nginx-proxy.tld"
-    HTTPS_METHOD: noredirect
+  labels:
+    '@proxy/virtualHost': "web3.nginx-proxy.tld"
+    '@proxy/httpsMethod': noredirect
 
 
 sut:

--- a/test/test_ssl/test_wildcard.yml
+++ b/test/test_ssl/test_wildcard.yml
@@ -4,7 +4,8 @@ web1:
     - "81"
   environment:
     WEB_PORTS: "81"
-    VIRTUAL_HOST: "*.nginx-proxy.tld"
+  labels:
+    '@proxy/virtualHost': "*.nginx-proxy.tld"
 
 sut:
   image: jwilder/nginx-proxy:test

--- a/test/test_ssl/wildcard_cert_and_nohttps/README.md
+++ b/test/test_ssl/wildcard_cert_and_nohttps/README.md
@@ -3,4 +3,4 @@ In this scenario, we have a wildcard certificate for `*.web.nginx-proxy.tld` and
 - 2.web.nginx-proxy.tld
 - 3.web.nginx-proxy.tld
 
-We want web containers 1 and 2 to support SSL, but 3 should not (using `HTTPS_METHOD=nohttps`)
+We want web containers 1 and 2 to support SSL, but 3 should not (using `@proxy/httpsMethod=nohttps`)

--- a/test/test_ssl/wildcard_cert_and_nohttps/docker-compose.yml
+++ b/test/test_ssl/wildcard_cert_and_nohttps/docker-compose.yml
@@ -15,14 +15,16 @@ services:
       - "81"
     environment:
       WEB_PORTS: "81"
-      VIRTUAL_HOST: "1.web.nginx-proxy.tld"
+    labels:
+      '@proxy/virtualHost': "1.web.nginx-proxy.tld"
   web2:
     image: web
     expose:
       - "82"
     environment:
       WEB_PORTS: "82"
-      VIRTUAL_HOST: "2.web.nginx-proxy.tld"
+    labels:
+      '@proxy/virtualHost': "2.web.nginx-proxy.tld"
 
   web3_nohttps:
     image: web
@@ -30,5 +32,6 @@ services:
       - "83"
     environment:
       WEB_PORTS: "83"
-      VIRTUAL_HOST: "3.web.nginx-proxy.tld"
-      HTTPS_METHOD: nohttps
+    labels:
+      '@proxy/virtualHost': "3.web.nginx-proxy.tld"
+      '@proxy/httpsMethod': nohttps

--- a/test/test_wildcard_host.yml
+++ b/test/test_wildcard_host.yml
@@ -4,7 +4,8 @@ web1:
     - "81"
   environment:
     WEB_PORTS: "81"
-    VIRTUAL_HOST: "*.nginx-proxy.test"
+  labels:
+    '@proxy/virtualHost': "*.nginx-proxy.test"
 
 web2:
   image: web
@@ -12,7 +13,8 @@ web2:
     - "82"
   environment:
     WEB_PORTS: "82"
-    VIRTUAL_HOST: "test.nginx-proxy.*"
+  labels:
+    '@proxy/virtualHost': "test.nginx-proxy.*"
 
 web3:
   image: web
@@ -20,7 +22,8 @@ web3:
     - "83"
   environment:
     WEB_PORTS: "83"
-    VIRTUAL_HOST: ~^web3\..*\.nginx-proxy\.regexp
+  labels:
+    '@proxy/virtualHost': ~^web3\..*\.nginx-proxy\.regexp
 
 web4:
   image: web
@@ -28,7 +31,8 @@ web4:
     - "84"
   environment:
     WEB_PORTS: "84"
-    VIRTUAL_HOST: ~^web4\..*\.nginx-proxy\.regexp$$ # we need to double the `$` because of docker-compose variable interpolation
+  labels:
+    '@proxy/virtualHost': ~^web4\..*\.nginx-proxy\.regexp$$ # we need to double the `$` because of docker-compose variable interpolation
 
 
 sut:


### PR DESCRIPTION
Removes the use of environment variables for defining virtual hosts. Environment variables are still used for configuring the proxy container itself (and potentially the add-on container for docker-gen)