### PR TITLE
Update Dockerfile.alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM nginx:1.14.1-alpine
+FROM nginx:stable-alpine
 LABEL maintainer="Jason Wilder mail@jasonwilder.com"
 
 # Install wget and install/updates certificates


### PR DESCRIPTION
I don't think that a static nginx version is a very good soultion, since security bugfixes would not be able without changing the static version in the dockerfile, so i think switching to the stable branch of nginx would be the best solution. I've tested this change and it works fine.