### PR TITLE
update base image to latest(current 1.17.1) to use tls 1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.14.1
+FROM nginx:latest
 LABEL maintainer="Jason Wilder mail@jasonwilder.com"
 
 # Install wget and install/updates certificates

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM nginx:1.14.1-alpine
+FROM nginx:alpine
 LABEL maintainer="Jason Wilder mail@jasonwilder.com"
 
 # Install wget and install/updates certificates


### PR DESCRIPTION
The mainline nginx:latest is not compiled with openssl 1.1.1 for now, so, it doesn't support tls 1.3
https://github.com/nginxinc/docker-nginx/issues/190

but the nginx:alpine supports tls 1.3 for now.

Tested,   with the alpine tag, tls 1.3 is successfuly applied.
