### PR TITLE
Revert "do not create an empty upstream entry for invisible containers"

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -142,9 +142,6 @@ upstream {{ $upstream_name }} {
 					{{ $address := where $container.Addresses "Port" $port | first }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{ end }}
-			{{ else }}
-				# Cannot connect to network of this container
-				server 127.0.0.1 down;
 			{{ end }}
 		{{ end }}
 	{{ end }}


### PR DESCRIPTION
Reverts jwilder/nginx-proxy#1106

This leads to invalid upstream entries being created if a backend container has multiple networks, of which some are not reachable from the proxy (quite common when proxying services that are managed with docker-compose and use an internal network for backend communications), resulting in an upstream record like this:
```
upstream service.zone.local {
                                # Cannot connect to network of this container
                                server 127.0.0.1 down;
                                ## Can be connected with "proxy" network
                        # service_example_1
                        server 172.20.0.3:80;
```